### PR TITLE
chore: change docker builder version(1.20=>1.18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      
+      - name: Setup Go 1.18
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18'
+      - run: go mod download
+      
       - name: Tests
         run: make test
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Setup Go 1.18
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18'
+      - run: go mod download
+      
       - name: check
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Setup Go 1.18
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.18'
+      - run: go mod download
+      
       - name: Run tests
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.20-alpine as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 


### PR DESCRIPTION
change the Go version used during build to 1.18 in order to use `mrand.Seed` which is deprecated since Go 1.20 and used in `trie/zk_trie_proof_test.go`
