### PR TITLE
feat: enable marshaling deposit tx with nonce

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -112,6 +112,20 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 			enc.Mint = (*hexutil.Big)(itx.Mint)
 		}
 		// other fields will show up as null.
+	// NOTE(chokobole): When unmarshalling the DepositTx from the RPC transaction format,
+	// it is transformed into depositTxWithNonce. This unexpected transformation can cause data loss,
+	// so this case statement was added as a temporary measure.
+	case *depositTxWithNonce:
+		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
+		enc.Value = (*hexutil.Big)(itx.Value)
+		enc.Data = (*hexutil.Bytes)(&itx.Data)
+		enc.To = tx.To()
+		enc.SourceHash = &itx.SourceHash
+		enc.From = &itx.From
+		if itx.Mint != nil {
+			enc.Mint = (*hexutil.Big)(itx.Mint)
+		}
+		// other fields will show up as null.
 	}
 	return json.Marshal(&enc)
 }


### PR DESCRIPTION
While implementing https://github.com/kroma-network/kroma/issues/17,
I faced the issue that a deposit transaction is transformed to
a deposit transaction with nonce during unmarshaling from rpc transaction.
The problem is marshaling of a transaction with nonce omits some of
properties this leads to several unexpected results.

This isn't meant to be a good solution for the regarding issue above.
For example, `SourceHash()` of a deposit transaction with nonce doesn't
return what we expect as a deposit transaction does.

Still, this is a enough change for me to get public input from output
root for ZK fault proof.