### PR TITLE
fix(core): fix discrepancy in receipt

### DIFF
--- a/cmd/evm/testdata/1/exp.json
+++ b/cmd/evm/testdata/1/exp.json
@@ -28,6 +28,7 @@
         "transactionHash": "0x0557bacce3375c98d806609b8d5043072f0b6a8bae45ae5a67a00d3a1a18d673",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5208",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/13/exp2.json
+++ b/cmd/evm/testdata/13/exp2.json
@@ -16,6 +16,7 @@
         "transactionHash": "0xa98a24882ea90916c6a86da650fbc6b14238e46f0af04a131ce92be897507476",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x84d0",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       },
@@ -29,6 +30,7 @@
         "transactionHash": "0x36bad80acce7040c45fd32764b5c2b2d2e6f778669fb41791f73f546d56e739a",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x84d0",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x1"
       }

--- a/cmd/evm/testdata/23/exp.json
+++ b/cmd/evm/testdata/23/exp.json
@@ -15,6 +15,7 @@
         "transactionHash": "0x72fadbef39cd251a437eea619cfeda752271a5faaaa2147df012e112159ffb81",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x520b",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/24/exp.json
+++ b/cmd/evm/testdata/24/exp.json
@@ -31,6 +31,7 @@
         "transactionHash": "0x92ea4a28224d033afb20e0cc2b290d4c7c2d61f6a4800a680e4e19ac962ee941",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0xa861",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       },
@@ -43,6 +44,7 @@
         "transactionHash": "0x16b1d912f1d664f3f60f4e1b5f296f3c82a64a1a253117b4851d18bc03c4f1da",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5aa5",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x1"
       }

--- a/cmd/evm/testdata/25/exp.json
+++ b/cmd/evm/testdata/25/exp.json
@@ -27,6 +27,7 @@
         "transactionHash": "0x92ea4a28224d033afb20e0cc2b290d4c7c2d61f6a4800a680e4e19ac962ee941",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x5208",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/cmd/evm/testdata/3/exp.json
+++ b/cmd/evm/testdata/3/exp.json
@@ -28,6 +28,7 @@
         "transactionHash": "0x72fadbef39cd251a437eea619cfeda752271a5faaaa2147df012e112159ffb81",
         "contractAddress": "0x0000000000000000000000000000000000000000",
         "gasUsed": "0x521f",
+        "effectiveGasPrice": null,
         "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "transactionIndex": "0x0"
       }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -16,25 +16,25 @@ var _ = (*receiptMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (r Receipt) MarshalJSON() ([]byte, error) {
 	type Receipt struct {
-		Type              hexutil.Uint64 `json:"type,omitempty"`
-		PostState         hexutil.Bytes  `json:"root"`
-		Status            hexutil.Uint64 `json:"status"`
-		CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             Bloom          `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log         `json:"logs"              gencodec:"required"`
-		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   common.Address `json:"contractAddress"`
-		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int       `json:"effectiveGasPrice,omitempty"`
-		DepositNonce      *uint64        `json:"depositNonce,omitempty"`
-		BlockHash         common.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
-		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
-		L1GasPrice        *hexutil.Big   `json:"l1GasPrice,omitempty"`
-		L1GasUsed         *hexutil.Big   `json:"l1GasUsed,omitempty"`
-		L1Fee             *hexutil.Big   `json:"l1Fee,omitempty"`
-		FeeScalar         *big.Float     `json:"l1FeeScalar,omitempty"`
-		ReturnValue       []byte         `json:"returnValue,omitempty"`
+		Type              hexutil.Uint64  `json:"type,omitempty"`
+		PostState         hexutil.Bytes   `json:"root"`
+		Status            hexutil.Uint64  `json:"status"`
+		CumulativeGasUsed hexutil.Uint64  `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom             Bloom           `json:"logsBloom"         gencodec:"required"`
+		Logs              []*Log          `json:"logs"              gencodec:"required"`
+		TxHash            common.Hash     `json:"transactionHash" gencodec:"required"`
+		ContractAddress   common.Address  `json:"contractAddress"`
+		GasUsed           hexutil.Uint64  `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
+		DepositNonce      *hexutil.Uint64 `json:"depositNonce,omitempty"`
+		BlockHash         common.Hash     `json:"blockHash,omitempty"`
+		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
+		TransactionIndex  hexutil.Uint    `json:"transactionIndex"`
+		L1GasPrice        *hexutil.Big    `json:"l1GasPrice,omitempty"`
+		L1GasUsed         *hexutil.Big    `json:"l1GasUsed,omitempty"`
+		L1Fee             *hexutil.Big    `json:"l1Fee,omitempty"`
+		FeeScalar         *big.Float      `json:"l1FeeScalar,omitempty"`
+		ReturnValue       []byte          `json:"returnValue,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -46,8 +46,8 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
-	enc.EffectiveGasPrice = r.EffectiveGasPrice
-	enc.DepositNonce = r.DepositNonce
+	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
+	enc.DepositNonce = (*hexutil.Uint64)(r.DepositNonce)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -71,8 +71,8 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
 		ContractAddress   *common.Address `json:"contractAddress"`
 		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *big.Int        `json:"effectiveGasPrice,omitempty"`
-		DepositNonce      *uint64         `json:"depositNonce,omitempty"`
+		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
+		DepositNonce      *hexutil.Uint64 `json:"depositNonce,omitempty"`
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
@@ -119,10 +119,10 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
 	if dec.EffectiveGasPrice != nil {
-		r.EffectiveGasPrice = dec.EffectiveGasPrice
+		r.EffectiveGasPrice = (*big.Int)(dec.EffectiveGasPrice)
 	}
 	if dec.DepositNonce != nil {
-		r.DepositNonce = dec.DepositNonce
+		r.DepositNonce = (*uint64)(dec.DepositNonce)
 	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -63,7 +63,7 @@ type Receipt struct {
 	TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	GasUsed           uint64         `json:"gasUsed" gencodec:"required"`
-	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"`
+	EffectiveGasPrice *big.Int       `json:"effectiveGasPrice"` // required, but tag omitted for backwards compatibility
 
 	// DepositNonce was introduced to store the actual nonce used by deposit transactions
 	// The state transition process ensures this is only set for deposit transactions.

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -93,6 +93,8 @@ type receiptMarshaling struct {
 	Status            hexutil.Uint64
 	CumulativeGasUsed hexutil.Uint64
 	GasUsed           hexutil.Uint64
+	EffectiveGasPrice *hexutil.Big
+	DepositNonce      *hexutil.Uint64
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint
 


### PR DESCRIPTION
In the kroma e2e test, errors occurred that `EffectiveGasPrice` and `DepositNonce` could not be unmarshaled. 
In this regard, there was some discrepancy between `receipt` and `gen_receipt_json.go`. 
Referring to this [PR](https://github.com/ethereum/go-ethereum/pull/27114), which was also reflected in `ethereum/go-ethereum`, `gen_receipt_json.go` has been regenerated and testdata were modified accordingly.

And the `EffectiveGasPrice` is required as described in [spec](https://github.com/ethereum/execution-apis/blob/af82a989bead35e2325ecc49a9023df39c548756/src/schemas/receipt.yaml#L49), so the `omitempty` tag has been removed.