### PR TITLE
feat: implement zk merkle tree

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -185,6 +185,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		cfg.Eth.OverrideKroma = &override
 	}
 	cfg.Eth.CircuitParams = new(params.CircuitParams)
+	cfg.Eth.ExperimentalZkTree = ctx.Bool(utils.ExperimentalZkTrie.Name)
 	if ctx.IsSet(utils.MaxTxsFlag.Name) {
 		maxTxs := ctx.Int(utils.MaxTxsFlag.Name)
 		cfg.Eth.CircuitParams.MaxTxs = &maxTxs

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -156,6 +156,7 @@ var (
 		// utils.RollupDisableTxPoolGossipFlag
 		// utils.RollupHaltOnIncompatibleProtocolVersionFlag,
 		utils.RollupComputePendingBlock,
+		utils.ExperimentalZkTrie,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -997,6 +997,12 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    metrics.DefaultConfig.InfluxDBOrganization,
 		Category: flags.MetricsCategory,
 	}
+
+	ExperimentalZkTrie = &cli.BoolFlag{
+		Name:     "zkstatetrie",
+		Usage:    "use ZkMerkleStateTrie instead of ZkTrie in state. This is an experimental flag.",
+		Category: flags.EthCategory,
+	}
 )
 
 var (

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -150,11 +150,13 @@ type CacheConfig struct {
 
 	SnapshotNoBuild bool // Whether the background generation is allowed
 	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+
+	ExperimentalZkTrie bool // use ZkMerkleStateTrie instead of ZkTrie
 }
 
 // triedbConfig derives the configures for trie database.
 func (c *CacheConfig) triedbConfig() *trie.Config {
-	config := &trie.Config{Preimages: c.Preimages}
+	config := &trie.Config{Preimages: c.Preimages, ExperimentalZkTrie: c.ExperimentalZkTrie}
 	if c.StateScheme == rawdb.HashScheme {
 		config.HashDB = &hashdb.Config{
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -176,6 +176,9 @@ type cachingDB struct {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
+	if db.triedb.IsZkStateTrie() {
+		return trie.NewZkMerkleStateTrie(root, db.triedb)
+	}
 	// [Scroll: START]
 	if db.triedb.IsZk() {
 		tr, err := trie.NewZkTrie(root, db.triedb)
@@ -194,6 +197,9 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Address, root common.Hash) (Trie, error) {
+	if db.triedb.IsZkStateTrie() {
+		return trie.NewZkMerkleStateTrie(root, db.triedb)
+	}
 	// [Scroll: START]
 	if db.triedb.IsZk() {
 		tr, err := trie.NewZkTrie(root, db.triedb)
@@ -219,6 +225,8 @@ func (db *cachingDB) CopyTrie(t Trie) Trie {
 	case *trie.ZkTrie:
 		return t.Copy()
 	// [Scroll: END]
+	case *trie.ZkMerkleStateTrie:
+		return t.Copy()
 	default:
 		panic(fmt.Errorf("unknown trie type %T", t))
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -200,6 +200,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			// [Scroll: START]
 			MPTWitness: config.MPTWitness,
 			// [Scroll: END]
+			ExperimentalZkTrie: config.ExperimentalZkTree,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -175,6 +175,8 @@ type Config struct {
 	MPTWitness int
 	// [Scroll: END]
 	CircuitParams *params.CircuitParams
+
+	ExperimentalZkTree bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/trie/database.go
+++ b/trie/database.go
@@ -36,6 +36,8 @@ type Config struct {
 	HashDB    *hashdb.Config // Configs for hash-based scheme
 	PathDB    *pathdb.Config // Configs for experimental path-based scheme
 	Zktrie    bool           // use zktrie
+
+	ExperimentalZkTrie bool // use zktree
 }
 
 // HashDefaults represents a config for using hash-based scheme with
@@ -355,22 +357,19 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	return zdb.Get(key)
 }
 
-func (db *Database) IsZk() bool {
-	if db.config == nil {
-		return false
-	}
-	return db.config.Zktrie
-}
+func (db *Database) IsZk() bool          { return db.config.Zktrie }
+func (db *Database) IsZkStateTrie() bool { return db.config.Zktrie && db.config.ExperimentalZkTrie }
 
 func (db *Database) SetBackend(isZk bool) {
 	if db.config.Zktrie == isZk {
 		return
 	}
 	db.config = &Config{
-		Preimages: db.config.Preimages,
-		HashDB:    db.config.HashDB,
-		PathDB:    db.config.PathDB,
-		Zktrie:    isZk,
+		Preimages:          db.config.Preimages,
+		HashDB:             db.config.HashDB,
+		PathDB:             db.config.PathDB,
+		Zktrie:             isZk,
+		ExperimentalZkTrie: db.config.ExperimentalZkTrie,
 	}
 	if db.config.PathDB != nil {
 		if isZk {

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -859,7 +859,7 @@ func zkMerkleTreeNodeBlobFunctions(findBlobByHash func(key []byte) ([]byte, erro
 				return &merkleTreeIteratorLeafNode{
 					hash: hash,
 					blob: n.Data(),
-					key:  n.KeyHash.Bytes(),
+					key:  zkt.ReverseByteOrder(n.Key),
 				}, nil
 			}
 			return nil, nil

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -640,7 +640,7 @@ func TestMerkleTreeIterator(t *testing.T) {
 	makeMerkleTreeWithData := func(input []kvs) (*ZkMerkleStateTrie, *memorydb.Database) {
 		db := memorydb.New()
 		zdb := NewZkDatabase(rawdb.NewDatabase(db))
-		tree := NewZkMerkleStateTrie(zk.NewEmptyMerkleTree(), zdb)
+		tree, _ := NewZkMerkleStateTrie(common.BytesToHash(zkt.HashZero.Bytes()), zdb)
 		for _, val := range input {
 			tree.Update(zk.MustNewSecureHash(common.LeftPadBytes([]byte(val.k), 32))[:], common.LeftPadBytes([]byte(val.v), 32))
 		}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -640,7 +640,7 @@ func TestMerkleTreeIterator(t *testing.T) {
 	makeMerkleTreeWithData := func(input []kvs) (*ZkMerkleStateTrie, *memorydb.Database) {
 		db := memorydb.New()
 		zdb := NewZkDatabase(rawdb.NewDatabase(db))
-		tree, _ := NewZkMerkleStateTrie(common.BytesToHash(zkt.HashZero.Bytes()), zdb)
+		tree := NewEmptyZkMerkleTrie(zdb)
 		for _, val := range input {
 			tree.Update(zk.MustNewSecureHash(common.LeftPadBytes([]byte(val.k), 32))[:], common.LeftPadBytes([]byte(val.v), 32))
 		}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -642,7 +642,7 @@ func TestMerkleTreeIterator(t *testing.T) {
 		zdb := NewZkDatabase(rawdb.NewDatabase(db))
 		tree := NewZkMerkleStateTrie(zk.NewEmptyMerkleTree(), zdb)
 		for _, val := range input {
-			tree.Update(common.LeftPadBytes([]byte(val.k), 32), common.LeftPadBytes([]byte(val.v), 32))
+			tree.Update(zk.MustNewSecureHash(common.LeftPadBytes([]byte(val.k), 32))[:], common.LeftPadBytes([]byte(val.v), 32))
 		}
 		rootHash, _, _ := tree.Commit(false)
 		zdb.Commit(rootHash, true)

--- a/trie/merkle_trie.go
+++ b/trie/merkle_trie.go
@@ -1,0 +1,94 @@
+package trie
+
+import (
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+/*
+There are quite a few pieces of code that use trie as a structure rather than an interface.
+The purpose of this file is to define an interface to make TRIE compatible with ZK.
+They are compatible as follows
+
+   geth      |  scroll   |    kroma
+   ----------------------------------------
+   Trie      |           |  ZkMerkleTrie
+   StackTrie |           |  ZkMerkleStackTrie
+   StateTrie |  ZkTrie   |  ZkMerkleStateTrie
+*/
+
+// MerkleTrie is a data structure that does not hash the key.
+// The main purpose is to make Trie and zk.MerkleTree compatible.
+// ZkTrie is not compatible with MerkleTrie because it always hashes keys.
+type MerkleTrie interface {
+	Hash() common.Hash
+	Get(key []byte) ([]byte, error)
+	MustUpdate(key, value []byte)
+	Update(key, value []byte) error
+	MustNodeIterator(start []byte) NodeIterator
+	NodeIterator(startKey []byte) (NodeIterator, error)
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
+}
+
+func NewMerkleTrie(id *ID, db *Database) (MerkleTrie, error) {
+	if db.IsZk() {
+		tree, err := zk.NewMerkleTreeFromHash(zkt.NewHashFromBytes(id.Root[:]), db.Get)
+		if err != nil {
+			return nil, err
+		}
+		return NewZkMerkleTrie(tree, db), nil
+	}
+	return New(id, db)
+}
+
+func NewEmptyMerkleTrie(db *Database) MerkleTrie {
+	if db.IsZk() {
+		return NewZkMerkleTrie(zk.NewEmptyMerkleTree(), db)
+	}
+	return NewEmpty(db)
+}
+
+type MerkleStackTrie interface {
+	Update([]byte, []byte) error
+	Commit() (h common.Hash, err error)
+	Hash() common.Hash
+}
+
+func NewMerkleStackTrie(writeFn NodeWriteFunc, isZk bool) MerkleStackTrie {
+	if isZk {
+		return NewZkStackTrie(writeFn, common.Hash{})
+	}
+	return NewStackTrie(writeFn)
+}
+
+func NewMerkleStackTrieWithOwner(writeFn NodeWriteFunc, owner common.Hash, isZk bool) MerkleStackTrie {
+	if isZk {
+		return NewZkStackTrie(writeFn, owner)
+	}
+	return NewStackTrieWithOwner(writeFn, owner)
+}
+
+// MerkleStateTrie Interface to make StateTrie and ZkTrie and ZkMerkleStateTrie compatible.
+type MerkleStateTrie interface {
+	Hash() common.Hash
+	MustGet(key []byte) []byte
+	UpdateAccount(address common.Address, account *types.StateAccount) error
+	MustUpdate(key, value []byte)
+	MustDelete(key []byte)
+	MustNodeIterator(start []byte) NodeIterator
+	Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error)
+	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
+}
+
+func NewMerkleStateTrie(id *ID, db *Database) (MerkleStateTrie, error) {
+	if db.IsZk() {
+		return NewZkTrie(id.Root, db)
+	}
+	return NewStateTrie(id, db)
+}

--- a/trie/merkle_trie.go
+++ b/trie/merkle_trie.go
@@ -87,6 +87,9 @@ type MerkleStateTrie interface {
 }
 
 func NewMerkleStateTrie(id *ID, db *Database) (MerkleStateTrie, error) {
+	if db.IsZkStateTrie() {
+		return NewZkMerkleStateTrie(id.Root, db)
+	}
 	if db.IsZk() {
 		return NewZkTrie(id.Root, db)
 	}

--- a/trie/zk/merkle_tree.go
+++ b/trie/zk/merkle_tree.go
@@ -1,0 +1,451 @@
+package zk
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/kroma-network/zktrie/trie"
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// MerkleTree wraps a tree with key hashing.
+// All access operations hash the key using poseidon computeNodeHash
+//
+// MerkleTree is not safe for concurrent use.
+type MerkleTree struct {
+	rootNode TreeNode
+	// Sets the maximum depth of the tree. Exceeding it will result in a [trie.ErrReachedMaxLevel] error.
+	maxLevels int
+	// findBlobByHash is a function that reads tree blob data by [TreeNode.Hash].
+	// It exists to decode the HashNode into the original TreeNode, so it is not needed if the HashNode cannot be created (e.g, rootNode is an EmptyNode).
+	findBlobByHash func(hash []byte) ([]byte, error)
+}
+
+func NewMerkleTreeFromHash(rootHash *zkt.Hash, findBlobByHash func(hash []byte) ([]byte, error)) (*MerkleTree, error) {
+	if bytes.Equal(rootHash.Bytes(), zkt.HashZero.Bytes()) {
+		return NewEmptyMerkleTree(), nil
+	}
+	blob, err := findBlobByHash(rootHash[:])
+	if err != nil {
+		return nil, err
+	}
+	rootNode, err := NewTreeNodeFromBlob(blob)
+	if err != nil {
+		return nil, err
+	}
+	setNodeHash(rootNode, rootHash)
+	return NewMerkleTree(rootNode).WithNodeBlobFinder(findBlobByHash), nil
+}
+
+func NewEmptyMerkleTree() *MerkleTree { return NewMerkleTree(EmptyNodeValue) }
+func NewMerkleTree(rootNode TreeNode) *MerkleTree {
+	return &MerkleTree{rootNode: rootNode, maxLevels: trie.NodeKeyValidBytes * 8}
+}
+
+func (t *MerkleTree) RootNode() TreeNode { return t.rootNode }
+func (t *MerkleTree) MaxLevels() int     { return t.maxLevels }
+
+func (t *MerkleTree) WithMaxLevels(maxLevels int) *MerkleTree {
+	t.maxLevels = maxLevels
+	return t
+}
+
+func (t *MerkleTree) WithNodeBlobFinder(findBlobByHash func(hash []byte) ([]byte, error)) *MerkleTree {
+	t.findBlobByHash = findBlobByHash
+	return t
+}
+
+// Hash returns the root hash of the MerkleTree.
+// It does not write to the database and can be used even if the MerkleTree doesn't have one.
+func (t *MerkleTree) Hash() []byte {
+	if err := t.ComputeAllNodeHash(nil); err != nil {
+		log.Error("Failed to compute hash", "err", err)
+		return []byte{}
+	}
+	return t.rootNode.Hash().Bytes()
+}
+
+// ComputeAllNodeHash Compute the node hash, and call the handleDirtyNode function.
+// handleDirtyNode is only called if the node hash is newly computed.
+func (t *MerkleTree) ComputeAllNodeHash(handleDirtyNode func(dirtyNode TreeNode) error) error {
+	return computeNodeHash(t.rootNode, handleDirtyNode)
+}
+
+// Get returns the value for key stored in the tree.
+// The value bytes must not be modified by the caller.
+func (t *MerkleTree) Get(key []byte) ([]byte, error) {
+	k, err := zkt.ToSecureKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return t.GetByNodeKey(zkt.NewHashFromBigInt(k))
+}
+
+// GetByNodeKey returns the value for key stored in the tree.
+// The value bytes must not be modified by the caller.
+func (t *MerkleTree) GetByNodeKey(nodeKey *zkt.Hash) ([]byte, error) {
+	node, err := t.GetLeafNode(nodeKey)
+	if err != nil {
+		if errors.Is(err, trie.ErrKeyNotFound) {
+			return nil, nil // according to https://github.com/ethereum/go-ethereum/blob/37f9d25ba027356457953eab5f181c98b46e9988/trie/trie.go#L135
+		}
+		return nil, err
+	}
+	return node.Data(), nil
+}
+
+// GetLeafNode is more underlying method than Get, which obtain a leaf node or nil if not exist.
+func (t *MerkleTree) GetLeafNode(nodeKey *zkt.Hash) (*LeafNode, error) {
+	node, path := t.rootNode, t.newTreePath(nodeKey)
+	for lvl := 0; lvl < t.maxLevels; lvl++ {
+		switch n := node.(type) {
+		case *ParentNode:
+			node = t.getChild(n, path.Get(lvl))
+		case *LeafNode:
+			if !bytes.Equal(nodeKey[:], n.KeyHash[:]) {
+				return nil, trie.ErrKeyNotFound
+			}
+			return n, nil
+		case *EmptyNode:
+			return nil, trie.ErrKeyNotFound
+		case *HashNode:
+			return nil, fmt.Errorf("GetLeafNode: encounter hash node. level %d, path %v", lvl, path[:lvl])
+		default:
+			return nil, trie.ErrInvalidNodeFound
+		}
+	}
+	return nil, trie.ErrKeyNotFound
+}
+
+// GetNodeByPath returns the tree node at the end of the path
+func (t *MerkleTree) GetNodeByPath(path TreePath) TreeNode {
+	node := t.rootNode
+	for i := 0; i < t.maxLevels; i++ {
+		parent, ok := node.(*ParentNode)
+		if !ok {
+			break
+		}
+		node = t.getChild(parent, path.Get(i))
+	}
+	return node
+}
+
+// Update associates key with value in the tree. Subsequent calls to Get will return value.
+//
+// The value bytes must not be modified by the caller while they are stored in the tree.
+func (t *MerkleTree) Update(key []byte, value []byte) error {
+	// https://github.com/kroma-network/zktrie/blob/b0f3ee937287a115ea44f0c188df27e4cd29dfa0/lib.go#L224
+	var vFlag uint32
+	var vPreimage []zkt.Byte32
+	switch len(value) {
+	case 32:
+		vFlag, vPreimage = 1, []zkt.Byte32{*zkt.NewByte32FromBytes(value)}
+	case 128:
+		vFlag, vPreimage = 4, []zkt.Byte32{
+			*zkt.NewByte32FromBytes(value[0:32]),
+			*zkt.NewByte32FromBytes(value[32:64]),
+			*zkt.NewByte32FromBytes(value[64:96]),
+			*zkt.NewByte32FromBytes(value[96:128]),
+		}
+	case 160:
+		vFlag, vPreimage = 8, []zkt.Byte32{
+			*zkt.NewByte32FromBytes(value[0:32]),
+			*zkt.NewByte32FromBytes(value[32:64]),
+			*zkt.NewByte32FromBytes(value[64:96]),
+			*zkt.NewByte32FromBytes(value[96:128]),
+			*zkt.NewByte32FromBytes(value[128:160]),
+		}
+	default:
+		return errors.New("unexpected buffer type")
+	}
+	return t.UpdateUnsafe(key, vFlag, vPreimage)
+}
+
+// UpdateUnsafe associates key with value in the tree. Subsequent calls to Get will return value.
+//
+// The value bytes must not be modified by the caller while they are stored in the tree.
+func (t *MerkleTree) UpdateUnsafe(key []byte, vFlag uint32, vPreimage []zkt.Byte32) error {
+	k, err := zkt.ToSecureKey(key)
+	if err != nil {
+		return err
+	}
+	return t.UpdateByNodeKey(zkt.NewHashFromBigInt(k), vFlag, vPreimage)
+}
+
+// UpdateByNodeKey updates a nodeKey & value into the MerkleTree.
+// Here the `nodeKey` determines the path from the Root to the Leaf.
+func (t *MerkleTree) UpdateByNodeKey(nodeKey *zkt.Hash, vFlag uint32, vPreimage []zkt.Byte32) error {
+	// verify that nodeKey is valid and fit inside the Finite Field.
+	if !zkt.CheckBigIntInField(nodeKey.BigInt()) {
+		return trie.ErrInvalidField
+	}
+
+	newLeafNode, path := NewLeafNode(nodeKey, vFlag, vPreimage), t.newTreePath(nodeKey)
+	newRoot, err := t.addLeaf(newLeafNode, t.rootNode, 0, path, true)
+	// sanity check
+	if errors.Is(err, trie.ErrEntryIndexAlreadyExists) {
+		panic("Encounter unexpected errortype: ErrEntryIndexAlreadyExists")
+	} else if err != nil {
+		return err
+	}
+	t.rootNode = newRoot
+	return nil
+}
+
+// addLeaf recursively adds a newLeaf in the MT while updating the path, and returns the node with added leaf.
+func (t *MerkleTree) addLeaf(
+	newLeaf *LeafNode,
+	currNode TreeNode,
+	lvl int,
+	path TreePath,
+	forceUpdate bool,
+) (TreeNode, error) {
+	if lvl > t.maxLevels-1 {
+		return nil, trie.ErrReachedMaxLevel
+	}
+	switch n := currNode.(type) {
+	case *ParentNode:
+		newNode, err := t.addLeaf(newLeaf, t.getChild(n, path.Get(lvl)), lvl+1, path, forceUpdate)
+		if err != nil {
+			log.Error("fail to addLeaf", "err", err, "level", lvl)
+			return nil, err
+		}
+		n.SetChild(path.Get(lvl), newNode) // Update the node to reflect the modified child
+		return n, nil
+	case *LeafNode:
+		if !bytes.Equal(newLeaf.KeyHash[:], n.KeyHash[:]) {
+			pathOldLeaf := t.newTreePath(n.KeyHash)
+			// We need to push newLeaf down until its path diverges from n's path
+			return t.pushLeaf(newLeaf, n, path, pathOldLeaf, lvl)
+		}
+		if bytes.Equal(newLeaf.CanonicalValue(), n.CanonicalValue()) {
+			return currNode, nil // do nothing, duplicate entry
+		}
+		if forceUpdate {
+			return newLeaf, nil
+		}
+		return nil, trie.ErrEntryIndexAlreadyExists
+	case *EmptyNode:
+		return newLeaf, nil
+	case *HashNode:
+		return nil, fmt.Errorf("addLeaf: encounter hash node. level %d, path %d", lvl, path[:lvl])
+	default:
+		return nil, trie.ErrInvalidNodeFound
+	}
+}
+
+// pushLeaf pushes an existing oldLeaf down until its path diverges from newLeaf,
+// at which point both leafs are stored, all while updating the path.
+// pushLeaf returns the parent node of oldLeaf and newLeaf
+func (t *MerkleTree) pushLeaf(
+	newLeaf *LeafNode,
+	oldLeaf *LeafNode,
+	newLeafPath TreePath,
+	oldLeafPath TreePath,
+	oldLeafLvl int,
+) (*ParentNode, error) {
+	forkLvl := oldLeafLvl
+	for ; newLeafPath[forkLvl] == oldLeafPath[forkLvl] && forkLvl < t.maxLevels-1; forkLvl++ {
+	}
+	if forkLvl == t.maxLevels-1 && newLeafPath[forkLvl] == oldLeafPath[forkLvl] {
+		return nil, trie.ErrReachedMaxLevel
+	}
+	parentNode := newParentNode(newLeafPath.Get(forkLvl), newLeaf, oldLeafPath.Get(forkLvl), oldLeaf)
+	for lvl := forkLvl - 1; lvl >= oldLeafLvl; lvl-- {
+		parentNode = newParentNode(newLeafPath.Get(lvl), parentNode, newLeafPath.GetOther(lvl), EmptyNodeValue)
+	}
+	return parentNode, nil
+}
+
+func (t *MerkleTree) Delete(key []byte) error {
+	k, err := zkt.ToSecureKey(key)
+	if err != nil {
+		return err
+	}
+	return t.DeleteByNodeKey(zkt.NewHashFromBigInt(k))
+}
+
+// DeleteByNodeKey removes the specified Key from the MerkleTree and updates the path
+// from the deleted key to the Root with the new values. This method removes
+// the key from the MerkleTree, but does not remove the old nodes from the
+// key-value database; this means that if the tree is accessed by an old Root
+// where the key was not deleted yet, the key will still exist. If is desired
+// to remove the key-values from the database that are not under the current
+// Root, an option could be to dump all the leafs (using mt.DumpLeafs) and
+// import them in a new MerkleTree in a new database (using
+// mt.ImportDumpedLeafs), but this will lose all the Root history of the MerkleTree
+func (t *MerkleTree) DeleteByNodeKey(nodeKey *zkt.Hash) error {
+	if !zkt.CheckBigIntInField(nodeKey.BigInt()) { // verify that k is valid and fit inside the Finite Field.
+		return trie.ErrInvalidField
+	}
+	node, path, pathNodes := t.rootNode, t.newTreePath(nodeKey), *new([]*ParentNode)
+	for i := 0; i < t.maxLevels; i++ {
+		switch n := node.(type) {
+		case *ParentNode:
+			pathNodes = append(pathNodes, n)
+			node = t.getChild(n, path.Get(i))
+			continue
+		case *LeafNode:
+			if bytes.Equal(nodeKey[:], n.KeyHash[:]) {
+				t.rmAndUpload(path, pathNodes)
+				return nil
+			}
+			return trie.ErrKeyNotFound
+		case *EmptyNode:
+			return trie.ErrKeyNotFound
+		case *HashNode:
+			return trie.ErrKeyNotFound
+		default:
+			return trie.ErrInvalidNodeFound
+		}
+	}
+	return trie.ErrKeyNotFound
+}
+
+// rmAndUpload removes the key, and goes up until the root updating all the nodes with the new values.
+// Following the traditional zktrie implementation, clearing a tree node does not clear the storage area.
+func (t *MerkleTree) rmAndUpload(path TreePath, pathNodes []*ParentNode) {
+	switch len(pathNodes) {
+	case 0: // The leaf node you want to remove is root node.
+		t.rootNode = EmptyNodeValue
+	case 1:
+		// root (ParentNode) --- LeafNode or ParentNode (promoted to root node)
+		//                    |- LeafNode (deleted)
+		t.rootNode = t.getChild(pathNodes[0], path.GetOther(0))
+	default:
+		lastSibling := t.getChild(pathNodes[len(pathNodes)-1], path.GetOther(len(pathNodes)-1))
+		defer func() {
+			if t.rootNode != lastSibling {
+				for _, node := range pathNodes {
+					clearNodeHash(node)
+				}
+			}
+		}()
+		if _, ok := lastSibling.(*ParentNode); ok {
+			// The sibling of the node to be deleted is the parent node. Add an EmptyNode to the location to be deleted.
+			// last ParentNode --- LeafNode (deleted) <- set empty node
+			//                  |- ParentNode (sibling)
+			pathNodes[len(pathNodes)-1].SetChild(path.Get(len(pathNodes)-1), EmptyNodeValue)
+			return
+		}
+		// The sibling of the node to be deleted is a LeafNode.
+		// Find a parent node whose sibling is not an empty node.
+		// last ParentNode --- LeafNode (deleted)
+		//                  |- LeafNode (sibling)
+		for i := len(pathNodes) - 2; i >= 0; i-- { // start parent of last ParentNode
+			clearNodeHash(pathNodes[i])
+			sibling := t.getChild(pathNodes[i], path.GetOther(i))
+			if _, ok := sibling.(*EmptyNode); ok {
+				// To shorten the path as much as possible, if the sibling node is an empty node, it will be moved up.
+				// (with only one LeafNode among Parent's children).
+				continue
+			}
+			// A node that can branch to a state with two or more LeafNodes.
+			// ... - ParentNode
+			//           |- last ParentNode (replaced to sibling)
+			//           |           |- LeafNode (deleted)
+			//           |           |- LeafNode (sibling)
+			//           |- not EmptyNode
+			pathNodes[i].SetChild(path.Get(i), lastSibling)
+			pathNodes = pathNodes[:i]
+			return
+		}
+		// if all sibling is zero, stop and store the sibling of the deleted leaf as root
+		t.rootNode = lastSibling
+	}
+}
+
+// Prove constructs a merkle proof for key. The result contains all encoded nodes
+// on the path to the value at key. The value itself is also included in the last
+// node and can be retrieved by verifying the proof.
+//
+// If the tree does not contain a value for key, the returned proof contains all
+// nodes of the longest existing prefix of the key (at least the root node), ending
+// with the node that proves the absence of the key.
+func (t *MerkleTree) Prove(key []byte, writeNode func(TreeNode) error) error {
+	// notice Prove in secure tree "pass through" the key instead of secure it
+	// this keep consistent behavior with geth's secure trie
+	k, err := zkt.NewHashFromCheckedBytes(key)
+	if err == nil {
+		err = t.ComputeAllNodeHash(nil)
+	}
+	if err == nil {
+		err = t.ProveByPath(t.newTreePath(k), func(n TreeNode) error {
+			if leaf, ok := n.(*LeafNode); ok {
+				leaf.KeyPreimage = zkt.NewByte32FromBytesPaddingZero(key)
+			}
+			return writeNode(n)
+		})
+	}
+	return err
+}
+
+// ProveByPath constructs a merkle proof for SMT, it respects the protocol used by the ethereum-trie
+// but save the node data with a compact form.
+func (t *MerkleTree) ProveByPath(path TreePath, writeNode func(TreeNode) error) error {
+	for i, node := 0, t.rootNode; i < t.maxLevels; i++ {
+		// TODO: notice here we may have broken some implicit on the proofDb:
+		// the key is not keccak(value) and it even can not be derived from the value by any means without an actual decoding
+		if err := writeNode(node); err != nil {
+			return err
+		}
+		switch n := node.(type) {
+		case *ParentNode:
+			node = t.getChild(n, path.Get(i))
+			continue
+		case *LeafNode:
+		case *EmptyNode:
+		case *HashNode:
+		default:
+			return trie.ErrInvalidNodeFound
+		}
+		return nil
+	}
+	return nil
+}
+
+func (t *MerkleTree) Copy() *MerkleTree {
+	return &MerkleTree{
+		rootNode:       t.rootNode,
+		maxLevels:      t.maxLevels,
+		findBlobByHash: t.findBlobByHash,
+	}
+}
+
+// getChild If the child node is a hash node, decode it and update the parent node.
+func (t *MerkleTree) getChild(node *ParentNode, path byte) TreeNode {
+	if hashNode, ok := node.Child(path).(*HashNode); ok {
+		if child := t.findNodeByHash(hashNode.Hash()); child != nil {
+			node.SetChild(path, child)
+		}
+	}
+	return node.Child(path)
+}
+
+// findNodeByHash finds a treeNode by hash. The TreeNode found is not always the most recent state node.
+// If compatibility mode is enabled, the intermediate state of the tree can be read from the dirtyNode.
+// The [ParentNode.Children] present in the dirtyNode must be HashNode (see copyNode).
+func (t *MerkleTree) findNodeByHash(hash *zkt.Hash) TreeNode {
+	if hash == nil || t.findBlobByHash == nil {
+		return nil
+	}
+	blob, err := t.findBlobByHash(hash[:])
+	if err != nil {
+		log.Error("fail to read blob by hash", "hash", hash, "err", err)
+		return nil
+	}
+	node, err := NewTreeNodeFromBlob(blob)
+	if err != nil {
+		log.Error("fail to decode node from blob", "hash", hash, "blob", blob, "err", err)
+		return nil
+	}
+	setNodeHash(node, hash)
+	return node
+}
+
+func (t *MerkleTree) newTreePath(nodeKey *zkt.Hash) TreePath {
+	return NewTreePathFromBytesAndMaxLevel(nodeKey[:], t.maxLevels)
+}

--- a/trie/zk/merkle_tree_node.go
+++ b/trie/zk/merkle_tree_node.go
@@ -1,0 +1,215 @@
+package zk
+
+import (
+	"bytes"
+	"encoding/binary"
+	"unsafe"
+
+	"github.com/kroma-network/zktrie/trie"
+	zkt "github.com/kroma-network/zktrie/types"
+)
+
+const NodeTypeHash trie.NodeType = 9
+
+type TreeNode interface {
+	Hash() *zkt.Hash
+
+	// Value returns the encoded bytes of a node, include all information of it
+	Value() []byte
+
+	// CanonicalValue returns the byte form of a node required to be persisted, and strip unnecessary fields
+	// from the encoding (current only KeyPreimage for Leaf node) to keep a minimum size for content being
+	// stored in backend storage
+	CanonicalValue() []byte
+}
+
+func NewTreeNodeFromBlob(b []byte) (TreeNode, error) {
+	if len(b) == 0 {
+		return nil, trie.ErrNodeBytesBadSize
+	}
+	switch trie.NodeType(b[0]) {
+	case trie.NodeTypeParent:
+		return newParentNodeFromBlob(b[1:])
+	case trie.NodeTypeLeaf:
+		return newLeafNodeFromBlob(b[1:])
+	case trie.NodeTypeEmpty:
+		return EmptyNodeValue, nil
+	case NodeTypeHash:
+		return NewHashNode(zkt.NewHashFromBytes(b[1:])), nil
+	default:
+		return nil, trie.ErrInvalidNodeFound
+	}
+}
+
+type ParentNode struct {
+	childL TreeNode
+	childR TreeNode
+	hash   *zkt.Hash
+}
+
+func newParentNode(child1Path byte, child1 TreeNode, child2Path byte, child2 TreeNode) *ParentNode {
+	n := &ParentNode{}
+	n.SetChild(child1Path, child1)
+	n.SetChild(child2Path, child2)
+	return n
+}
+
+func newParentNodeFromBlob(blob []byte) (*ParentNode, error) {
+	if len(blob) != 2*zkt.HashByteLen {
+		return nil, trie.ErrNodeBytesBadSize
+	}
+	return &ParentNode{
+		NewHashNode(zkt.NewHashFromBytes(blob[:zkt.HashByteLen])),
+		NewHashNode(zkt.NewHashFromBytes(blob[zkt.HashByteLen : 2*zkt.HashByteLen])),
+		nil,
+	}, nil
+}
+
+func (n *ParentNode) Hash() *zkt.Hash { return n.hash }
+
+func (n *ParentNode) Value() []byte { return n.CanonicalValue() }
+
+func (n *ParentNode) CanonicalValue() []byte {
+	values := []byte{byte(trie.NodeTypeParent)}
+	values = append(values, n.childL.Hash().Bytes()...)
+	values = append(values, n.childR.Hash().Bytes()...)
+	return values
+}
+
+func (n *ParentNode) Child(path byte) TreeNode {
+	if path == right {
+		return n.childR
+	}
+	return n.childL
+}
+
+// SetChild Sets the child and clears the hash.
+func (n *ParentNode) SetChild(path byte, child TreeNode) {
+	oldChild := n.Child(path)
+	if path == right {
+		n.childR = child
+	} else {
+		n.childL = child
+	}
+	if _, ok := oldChild.(*HashNode); ok && child.Hash() != nil && bytes.Equal(oldChild.Hash()[:], child.Hash()[:]) {
+		// This is a case of converting a HashNode to the original TreeNode. Does not clear the hash.
+		return
+	}
+	n.hash = nil
+}
+
+func (n *ParentNode) ChildL() TreeNode      { return n.childL }
+func (n *ParentNode) ChildR() TreeNode      { return n.childR }
+func (n *ParentNode) Children() [2]TreeNode { return [2]TreeNode{n.childL, n.childR} }
+
+type LeafNode struct {
+	KeyHash *zkt.Hash
+
+	// KeyPreimage is the original key value that derives the NodeKey, kept here only for proof
+	KeyPreimage *zkt.Byte32
+
+	// valueHash is the cache of the hash of valuePreimage to avoid recalculating, only valid for leaf node
+	ValueHash *zkt.Hash
+
+	// ValuePreimage can store at most 256 byte32 as fields (represented by BIG-ENDIAN integer)
+	// and the first 24 can be compressed (each bytes32 consider as 2 fields), in hashing the compressed
+	// elements would be calculated first
+	ValuePreimage []zkt.Byte32
+
+	// CompressedFlags use each bit for indicating the compressed flag for the first 24 fields
+	CompressedFlags uint32
+
+	hash *zkt.Hash
+}
+
+func NewLeafNode(nodeKey *zkt.Hash, flags uint32, valuePreimage []zkt.Byte32) *LeafNode {
+	return &LeafNode{KeyHash: nodeKey, CompressedFlags: flags, ValuePreimage: valuePreimage}
+}
+
+// blob format is described in LeafNode.CanonicalValue
+func newLeafNodeFromBlob(blob []byte) (*LeafNode, error) {
+	if len(blob) < zkt.HashByteLen+4 {
+		return nil, trie.ErrNodeBytesBadSize
+	}
+	hashBlob := blob[:zkt.HashByteLen]
+	mark := binary.LittleEndian.Uint32(blob[zkt.HashByteLen : zkt.HashByteLen+4])
+	blob = blob[zkt.HashByteLen+4:]
+	node := &LeafNode{
+		KeyHash:         zkt.NewHashFromBytes(hashBlob),
+		CompressedFlags: mark >> 8,
+		ValuePreimage:   make([]zkt.Byte32, int(mark&255)),
+	}
+	if len(blob) < len(node.ValuePreimage)*32+1 {
+		return nil, trie.ErrNodeBytesBadSize
+	}
+	for i := 0; i < len(node.ValuePreimage); i++ {
+		copy(node.ValuePreimage[i][:], blob[i*32:(i+1)*32])
+	}
+	blob = blob[len(node.ValuePreimage)*32:]
+	if preImageSize := int(blob[0]); preImageSize != 0 {
+		if len(blob) < 1+preImageSize {
+			return nil, trie.ErrNodeBytesBadSize
+		}
+		node.KeyPreimage = new(zkt.Byte32)
+		copy(node.KeyPreimage[:], blob[1:1+preImageSize])
+	}
+	return node, nil
+}
+
+func (n *LeafNode) Hash() *zkt.Hash { return n.hash }
+
+// Value returns the encoded bytes of a node, include all information of it
+func (n *LeafNode) Value() []byte {
+	value := n.CanonicalValue()
+	if n.KeyPreimage != nil {
+		value[len(value)-1] = byte(len(n.KeyPreimage))
+		value = append(value, n.KeyPreimage[:]...)
+	}
+	return value
+}
+
+// CanonicalValue [type, Key[0], ..., Key[31], mark[0], ..., mark[3], Data[0], ..., Data[32*len(ValuePreimage)], key preimage len]
+// Leaf node does not provide key preimage, so set the length to 0.
+// If you can provide the key preimage, change the last 0 and add the key preimage afterwards. See ZkMerkleStateTrie.Prove
+func (n *LeafNode) CanonicalValue() []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(byte(trie.NodeTypeLeaf))
+	buf.Write(n.KeyHash.Bytes())
+	binary.Write(&buf, binary.LittleEndian, (n.CompressedFlags<<8)+uint32(len(n.ValuePreimage)))
+	buf.Write(n.Data())
+	buf.WriteByte(0) // key preimage len
+	return buf.Bytes()
+}
+
+func (n *LeafNode) Data() []byte {
+	ptr := *(*[]byte)(unsafe.Pointer(&n.ValuePreimage))
+	return unsafe.Slice(unsafe.SliceData(ptr), 32*len(n.ValuePreimage))
+}
+
+type HashNode zkt.Hash
+
+func NewHashNode(hash *zkt.Hash) TreeNode {
+	if bytes.Equal(hash[:], zkt.HashZero[:]) {
+		return EmptyNodeValue
+	}
+	node := HashNode(*hash)
+	return &node
+}
+
+func (n *HashNode) Hash() *zkt.Hash {
+	hash := zkt.Hash(*n)
+	return &hash
+}
+
+func (n *HashNode) Value() []byte { return n.CanonicalValue() }
+func (n *HashNode) CanonicalValue() []byte {
+	return append([]byte{byte(NodeTypeHash)}, n.Hash().Bytes()...)
+}
+
+type EmptyNode struct{}
+
+func (EmptyNode) Hash() *zkt.Hash        { return &zkt.HashZero }
+func (EmptyNode) Value() []byte          { return []byte{byte(trie.NodeTypeEmpty)} }
+func (EmptyNode) CanonicalValue() []byte { return []byte{byte(trie.NodeTypeEmpty)} }
+
+var EmptyNodeValue = &EmptyNode{}

--- a/trie/zk/merkle_tree_test.go
+++ b/trie/zk/merkle_tree_test.go
@@ -1,0 +1,164 @@
+package zk
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/kroma-network/zktrie/trie"
+	. "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/poseidon"
+)
+
+func init() { InitHashScheme(poseidon.HashFixed) }
+
+func newEmptyZkTrie() *trie.ZkTrie {
+	// A trie generated from an empty root will not raise an error.
+	zktrie, _ := trie.NewZkTrie(Byte32{}, trie.NewZkTrieMemoryDb())
+	return zktrie
+}
+
+func TestHash(t *testing.T) {
+	for leafCount := 0; leafCount <= 200; leafCount++ {
+		t.Run(fmt.Sprintf("test leaf count %d", leafCount), func(t *testing.T) { testUpdateAndHash(t, leafCount) })
+	}
+}
+
+func TestHash1000(t *testing.T) { testUpdateAndHash(t, 1000) }
+
+func testUpdateAndHash(t *testing.T, inputCount int) {
+	zktrie, zktree := newEmptyZkTrie(), NewEmptyMerkleTree()
+	input := newTestInputFixedCount(inputCount)
+	input.applyZkTrie(zktrie).applyZkTrees(zktree)
+	if !bytes.Equal(zktrie.Hash(), zktree.Hash()) {
+		t.Fatalf("invalid hash. want : %x, but got %x", zktrie.Hash(), zktree.Hash())
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Run("leaf count 1", func(t *testing.T) {
+		zktree := NewEmptyMerkleTree()
+		input := newTestInputFixedCount(1).applyZkTrees(zktree)
+		if err := zktree.DeleteByNodeKey(MustNewSecureHash([]byte(input.keys[0]))); err != nil {
+			t.Errorf("fail to delete. error : %v", err)
+		}
+		if !bytes.Equal(zktree.Hash(), common.Hash{}.Bytes()) {
+			t.Errorf("root not empty node")
+		}
+	})
+	for leafCount := 10; leafCount <= 100; leafCount++ {
+		t.Run(fmt.Sprintf("leaf count %d", leafCount), func(t *testing.T) {
+			zktrie, zktree := newEmptyZkTrie(), NewEmptyMerkleTree()
+			input := newTestInputFixedCount(leafCount).applyZkTrie(zktrie).applyZkTrees(zktree)
+			deleteKeys := input.keys[:leafCount/3]
+			for _, key := range deleteKeys {
+				zktrie.TryDelete([]byte(key))
+				zktree.Delete([]byte(key))
+			}
+			if !bytes.Equal(zktrie.Hash()[:], zktree.Hash()[:]) {
+				t.Errorf("root mismatch!")
+			}
+		})
+	}
+}
+
+func TestPushLeaf(t *testing.T) {
+	pushLeaf := func(newLeafPath TreePath, oldLeafPath TreePath) (*ParentNode, error) {
+		return NewEmptyMerkleTree().WithMaxLevels(4).pushLeaf(
+			NewLeafNode(NewHashFromBytes([]byte("new")), 1, []Byte32{*NewByte32FromBytes([]byte{0})}),
+			NewLeafNode(NewHashFromBytes([]byte("old")), 1, []Byte32{*NewByte32FromBytes([]byte{1})}),
+			newLeafPath,
+			oldLeafPath,
+			0,
+		)
+	}
+	t.Run("should return ErrReachedMaxLevel", func(t *testing.T) {
+		_, err := pushLeaf([]byte{0, 1, 0, 1}, []byte{0, 1, 0, 1})
+		if !errors.Is(err, trie.ErrReachedMaxLevel) {
+			t.Errorf("pushLeaf test failed.")
+		}
+	})
+	t.Run("insert max level", func(t *testing.T) {
+		parent, err := pushLeaf([]byte{0, 1, 0, 0}, []byte{0, 1, 0, 1})
+		if err != nil {
+			t.Errorf("pushLeaf test failed.")
+		}
+		for _, p := range []byte{0, 1, 0} {
+			parent = parent.Child(p).(*ParentNode)
+		}
+		for _, node := range parent.Children() {
+			if _, ok := node.(*LeafNode); !ok {
+				t.Errorf("")
+			}
+		}
+	})
+}
+
+func TestProof(t *testing.T) {
+	for leafCount := 1; leafCount <= 200; leafCount++ {
+		t.Run(fmt.Sprintf("test leaf count %d", leafCount), func(t *testing.T) {
+			input := newTestInputFixedCount(leafCount)
+			zktrie, zktree := newEmptyZkTrie(), NewEmptyMerkleTree()
+			input.applyZkTrie(zktrie).applyZkTrees(zktree)
+			for tc := 0; tc < int(math.Min(float64(leafCount), float64(10))); tc++ {
+				testKey := []byte(input.keys[rand.Intn(leafCount)])
+				trieHashs, treeHashs := *new([]*Hash), *new([]*Hash)
+				zktrie.Prove(testKey, 0, func(node *trie.Node) error {
+					hash, err := node.NodeHash()
+					trieHashs = append(trieHashs, hash)
+					return err
+				})
+				zktree.Prove(testKey, func(node TreeNode) error {
+					treeHashs = append(treeHashs, node.Hash())
+					return nil
+				})
+				if len(trieHashs) != len(treeHashs) {
+					t.Errorf("proof count mismatch. trie %d, tree %d", len(trieHashs), len(treeHashs))
+				}
+				for i := 0; i < len(trieHashs); i++ {
+					if !bytes.Equal(trieHashs[i].Bytes(), treeHashs[i].Bytes()) {
+						t.Errorf("index %d proof mismatch", i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUpdateAndHash(b *testing.B) {
+	type testTree struct {
+		Update func(key []byte, vFlag uint32, vPreimage []Byte32) error
+		Hash   func() []byte
+	}
+	makeTest := func(input *testInput, initTree func() *testTree) func(b *testing.B) {
+		return func(sub *testing.B) {
+			for i := 0; i < sub.N; i++ {
+				tree := initTree()
+				sub.ReportAllocs()
+				sub.StartTimer()
+				input.forEach(func(k, v []byte) {
+					tree.Update(k, 1, []Byte32{*NewByte32FromBytes(v)})
+				})
+				tree.Hash()
+				sub.StopTimer()
+			}
+		}
+	}
+	for i := 0; i < 10; i++ {
+		input := newTestInputFixedCount(200)
+		b.Run("trie", makeTest(input, func() *testTree {
+			zkTrie := newEmptyZkTrie()
+			return &testTree{Update: zkTrie.TryUpdate, Hash: zkTrie.Hash}
+		}))
+
+		b.Run("tree", makeTest(input, func() *testTree {
+			tree := NewEmptyMerkleTree()
+			return &testTree{Update: tree.UpdateUnsafe, Hash: tree.Hash}
+		}))
+	}
+}

--- a/trie/zk/testinput_test.go
+++ b/trie/zk/testinput_test.go
@@ -1,0 +1,52 @@
+package zk
+
+import (
+	"math/rand"
+
+	zktrie "github.com/kroma-network/zktrie/trie"
+	. "github.com/kroma-network/zktrie/types"
+)
+
+type testInput struct {
+	keys   []string
+	values []string
+}
+
+func newTestInputFixedCount(count int) *testInput {
+	return (&testInput{}).generate(count, rand.New(rand.NewSource(1)))
+}
+
+func (t *testInput) generate(count int, rnd *rand.Rand) *testInput {
+	for i := 0; i < count; i++ {
+		t.keys = append(t.keys, randomString(rnd, 32))
+		t.values = append(t.values, randomString(rnd, 32))
+	}
+	return t
+}
+
+func (t *testInput) applyZkTrie(trie *zktrie.ZkTrie) *testInput {
+	t.forEach(func(k, v []byte) { trie.TryUpdate(k, 1, []Byte32{*NewByte32FromBytes(v)}) })
+	return t
+}
+func (t *testInput) applyZkTrees(trees ...*MerkleTree) *testInput {
+	t.forEach(func(k, v []byte) {
+		for _, tree := range trees {
+			tree.UpdateUnsafe(k, 1, []Byte32{*NewByte32FromBytes(v)})
+		}
+	})
+	return t
+}
+
+func (t *testInput) forEach(callback func(k, v []byte)) {
+	for i := 0; i < t.len(); i++ {
+		callback([]byte(t.keys[i]), []byte(t.values[i]))
+	}
+}
+
+func (t *testInput) len() int { return len(t.keys) }
+
+func randomString(rnd *rand.Rand, strlen int) string {
+	b := make([]byte, strlen)
+	rnd.Read(b)
+	return string(b)
+}

--- a/trie/zk/testinput_test.go
+++ b/trie/zk/testinput_test.go
@@ -31,7 +31,7 @@ func (t *testInput) applyZkTrie(trie *zktrie.ZkTrie) *testInput {
 func (t *testInput) applyZkTrees(trees ...*MerkleTree) *testInput {
 	t.forEach(func(k, v []byte) {
 		for _, tree := range trees {
-			tree.UpdateUnsafe(k, 1, []Byte32{*NewByte32FromBytes(v)})
+			tree.Update(MustNewSecureHash(k)[:], v)
 		}
 	})
 	return t

--- a/trie/zk/tree_path.go
+++ b/trie/zk/tree_path.go
@@ -1,0 +1,67 @@
+package zk
+
+import (
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TreePath 0 left, 1 right
+type TreePath []byte
+
+const (
+	left  = byte(0)
+	right = byte(1)
+)
+
+func NewTreePathFromHash(hash common.Hash) TreePath {
+	return NewTreePathFromBytesAndMaxLevel(zkt.ReverseByteOrder(hash[:]), len(hash)*8)
+}
+
+func NewTreePathFromZkHash(hash zkt.Hash) TreePath {
+	return NewTreePathFromBytesAndMaxLevel(hash[:], len(hash)*8)
+}
+
+func NewTreePathFromBytes(bytes []byte) TreePath {
+	return NewTreePathFromBytesAndMaxLevel(bytes, len(bytes)*8)
+}
+
+func NewTreePathFromBytesAndMaxLevel(bytes []byte, maxLevel int) TreePath {
+	path := make(TreePath, maxLevel)
+	for n := 0; n < maxLevel; n++ {
+		if zkt.TestBit(bytes[:], uint(n)) {
+			path[n] = right
+		} else {
+			path[n] = left
+		}
+	}
+	return path
+}
+
+func NewTreePath(path []byte) TreePath { return path }
+
+func (p TreePath) Get(depth int) byte      { return p[depth] }
+func (p TreePath) GetOther(depth int) byte { return p[depth] ^ right }
+
+func (p TreePath) ToHash() *common.Hash {
+	hash := common.BytesToHash(p.ToZkHash().Bytes())
+	return &hash
+}
+
+func (p TreePath) ToZkHash() *zkt.Hash {
+	var zkHash zkt.Hash
+	copy(zkHash[:], p.toHexBytes())
+	return &zkHash
+}
+
+func (p TreePath) toHexBytes() []byte {
+	bytes := make([]byte, len(p)/8)
+	for i := 0; i < len(p); i += 8 {
+		var value byte
+		for _, path := range zkt.ReverseByteOrder(p[i : i+8]) {
+			value = (value << 1) | path
+		}
+		bytes[i/8] = value
+	}
+	return bytes
+}

--- a/trie/zk/tree_path_test.go
+++ b/trie/zk/tree_path_test.go
@@ -1,0 +1,26 @@
+package zk
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/crypto/poseidon"
+)
+
+func TestNewTreePathFromZkHash(t *testing.T) {
+	zkt.InitHashScheme(poseidon.HashFixed)
+	rand := rand.New(rand.NewSource(1))
+	for i := 0; i < 10000; i++ {
+		k, _ := zkt.ToSecureKey([]byte(randomString(rand, 32)))
+		input := zkt.NewHashFromBigInt(k)
+
+		path := NewTreePathFromZkHash(*input)
+
+		if !bytes.Equal(input[:], path.ToZkHash()[:]) {
+			t.Fatalf("test fail")
+		}
+	}
+}

--- a/trie/zk/util.go
+++ b/trie/zk/util.go
@@ -1,0 +1,78 @@
+package zk
+
+import (
+	"math/big"
+
+	zkt "github.com/kroma-network/zktrie/types"
+)
+
+var bigOne = big.NewInt(1)
+
+func NewSecureHash(b []byte) (*zkt.Hash, error) {
+	k, err := zkt.ToSecureKey(b)
+	if err != nil {
+		return nil, err
+	}
+	return zkt.NewHashFromBigInt(k), nil
+}
+
+func MustNewSecureHash(b []byte) *zkt.Hash {
+	hash, err := NewSecureHash(b)
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+func clearNodeHash(n TreeNode) {
+	switch node := n.(type) {
+	case *ParentNode:
+		node.hash = nil
+	case *LeafNode:
+		node.ValueHash = nil
+		node.hash = nil
+	case *EmptyNode:
+	case *HashNode:
+	}
+}
+
+func setNodeHash(n TreeNode, hash *zkt.Hash) {
+	switch node := n.(type) {
+	case *ParentNode:
+		node.hash = hash
+	case *LeafNode:
+		node.hash = hash
+	case *EmptyNode:
+	case *HashNode:
+	}
+}
+
+func computeNodeHash(n TreeNode, handleDirtyNode func(dirtyNode TreeNode) error) (err error) {
+	switch node := n.(type) {
+	case *ParentNode:
+		if node.hash == nil {
+			for _, child := range node.Children() {
+				if err = computeNodeHash(child, handleDirtyNode); err != nil {
+					return err
+				}
+			}
+			node.hash, err = zkt.HashElems(node.ChildL().Hash().BigInt(), node.ChildR().Hash().BigInt())
+			if err == nil && handleDirtyNode != nil {
+				err = handleDirtyNode(node)
+			}
+		}
+	case *LeafNode:
+		if node.ValueHash == nil {
+			node.ValueHash, err = zkt.PreHandlingElems(node.CompressedFlags, node.ValuePreimage)
+		}
+		if node.hash == nil && err == nil {
+			node.hash, err = zkt.HashElems(bigOne, node.KeyHash.BigInt(), node.ValueHash.BigInt())
+			if err == nil && handleDirtyNode != nil {
+				err = handleDirtyNode(node)
+			}
+		}
+	case *EmptyNode:
+	case *HashNode:
+	}
+	return
+}

--- a/trie/zk_merkle_stack_trie.go
+++ b/trie/zk_merkle_stack_trie.go
@@ -1,0 +1,39 @@
+package trie
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+type ZkMerkleStackTrie struct {
+	*zk.MerkleTree
+	writeFn NodeWriteFunc
+	owner   common.Hash
+}
+
+func NewZkStackTrie(writeFn NodeWriteFunc, owner common.Hash) *ZkMerkleStackTrie {
+	return &ZkMerkleStackTrie{MerkleTree: zk.NewEmptyMerkleTree(), writeFn: writeFn, owner: owner}
+}
+
+func (z *ZkMerkleStackTrie) Update(hash []byte, value []byte) error {
+	return z.MerkleTree.Update(hash, value)
+}
+
+func (z *ZkMerkleStackTrie) Commit() (h common.Hash, err error) {
+	var handleDirtyNode func(dirtyNode zk.TreeNode) error
+	if z.writeFn != nil {
+		handleDirtyNode = func(n zk.TreeNode) error {
+			z.writeFn(z.owner, zk.NewTreePathFromZkHash(*n.Hash()), common.BytesToHash(n.Hash().Bytes()), n.CanonicalValue())
+			return nil
+		}
+	}
+	if err = z.ComputeAllNodeHash(handleDirtyNode); err != nil {
+		return common.Hash{}, err
+	}
+	return common.BytesToHash(z.RootNode().Hash().Bytes()), nil
+}
+
+func (z *ZkMerkleStackTrie) Hash() common.Hash {
+	root, _ := z.Commit()
+	return root
+}

--- a/trie/zk_merkle_state_trie.go
+++ b/trie/zk_merkle_state_trie.go
@@ -1,0 +1,123 @@
+package trie
+
+import (
+	zktrie "github.com/kroma-network/zktrie/trie"
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+type ZkMerkleStateTrie struct {
+	*zk.MerkleTree
+	db *Database
+}
+
+func NewZkMerkleStateTrie(tree *zk.MerkleTree, db *Database) *ZkMerkleStateTrie {
+	return &ZkMerkleStateTrie{MerkleTree: tree, db: db}
+}
+
+func (z *ZkMerkleStateTrie) GetKey(kHashBytes []byte) []byte {
+	// TODO: use a kv cache in memory
+	k, err := zkt.NewBigIntFromHashBytes(kHashBytes)
+	if err != nil {
+		log.Error("Unhandled trie error in ZkMerkleStateTrie.GetKey", "err", err)
+	}
+	if z.db.preimages == nil {
+		return nil
+	}
+	return z.db.preimages.preimage(common.BytesToHash(k.Bytes()))
+}
+
+func (z *ZkMerkleStateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
+	sanityCheckByte32Key(key)
+	return z.Get(key)
+}
+
+func (z *ZkMerkleStateTrie) GetAccount(address common.Address) (*types.StateAccount, error) {
+	blob, err := z.Get(address.Bytes())
+	if blob == nil || err != nil {
+		return nil, err
+	}
+	return types.UnmarshalStateAccount(blob)
+}
+
+func (z *ZkMerkleStateTrie) UpdateStorage(_ common.Address, key, value []byte) error {
+	sanityCheckByte32Key(key)
+	return z.MerkleTree.UpdateUnsafe(key, 1, []zkt.Byte32{*zkt.NewByte32FromBytes(value)})
+}
+
+func (z *ZkMerkleStateTrie) UpdateAccount(address common.Address, account *types.StateAccount) error {
+	sanityCheckByte32Key(address.Bytes())
+	value, flag := account.MarshalFields()
+	return z.MerkleTree.UpdateUnsafe(address.Bytes(), flag, value)
+}
+
+func (z *ZkMerkleStateTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte) error {
+	return nil
+}
+
+func (z *ZkMerkleStateTrie) DeleteStorage(_ common.Address, key []byte) error {
+	sanityCheckByte32Key(key)
+	return z.MerkleTree.Delete(key)
+}
+
+func (z *ZkMerkleStateTrie) DeleteAccount(address common.Address) error {
+	return z.MerkleTree.Delete(address.Bytes())
+}
+
+func (z *ZkMerkleStateTrie) Hash() common.Hash {
+	hash, _, _ := z.Commit(false)
+	return hash
+}
+
+func (z *ZkMerkleStateTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, error) {
+	err := z.ComputeAllNodeHash(func(node zk.TreeNode) error { return z.db.Put(node.Hash()[:], node.CanonicalValue()) })
+	if err != nil {
+		log.Error("Failed to commit zk merkle trie", "err", err)
+	}
+	rawdb.WriteLegacyTrieNode(z.db.diskdb, common.BytesToHash(z.RootNode().Hash().Bytes()), z.RootNode().Value())
+	// Since NodeSet relies directly on mpt, we can't create a NodeSet.
+	// Of course, we might be able to force-fit it by implementing the node interface.
+	// However, NodeSet has been improved in geth, it could be improved to return a NodeSet when a commit is applied.
+	// So let's not do that for the time being.
+	// related geth commit : https://github.com/ethereum/go-ethereum/commit/bbcb5ea37b31c48a59f9aa5fad3fd22233c8a2ae
+	return common.BytesToHash(z.MerkleTree.Hash()), nil, nil
+}
+
+func (z *ZkMerkleStateTrie) NodeIterator(startKey []byte) (NodeIterator, error) {
+	panic("not implemented")
+}
+
+func (z *ZkMerkleStateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
+	err := z.MerkleTree.Prove(key, func(node zk.TreeNode) error {
+		if leaf, ok := node.(*zk.LeafNode); ok {
+			preImage := z.GetKey(leaf.KeyHash.Bytes())
+			if len(preImage) > 0 {
+				leaf.KeyPreimage = &zkt.Byte32{}
+				copy(leaf.KeyPreimage[:], preImage)
+			}
+		}
+		return proofDb.Put(node.Hash()[:], node.Value())
+	})
+	if err != nil {
+		return err
+	}
+	// we put this special kv pair in db so we can distinguish the type and make suitable Proof
+	return proofDb.Put(magicHash, zktrie.ProofMagicBytes())
+}
+
+func (z *ZkMerkleStateTrie) GetNode(path []byte) ([]byte, int, error) { panic("implement me") }
+
+func (z *ZkMerkleStateTrie) Update(key, value []byte) error {
+	return z.MerkleTree.Update(key, value)
+}
+
+func (z *ZkMerkleStateTrie) Copy() *ZkMerkleStateTrie {
+	return &ZkMerkleStateTrie{z.MerkleTree.Copy(), z.db}
+}

--- a/trie/zk_merkle_state_trie.go
+++ b/trie/zk_merkle_state_trie.go
@@ -91,7 +91,8 @@ func (z *ZkMerkleStateTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, erro
 }
 
 func (z *ZkMerkleStateTrie) NodeIterator(startKey []byte) (NodeIterator, error) {
-	panic("not implemented")
+	nodeBlobFromTree, nodeBlobToIteratorNode := zkMerkleTreeNodeBlobFunctions(z.db.Get)
+	return newMerkleTreeIterator(z.Hash(), nodeBlobFromTree, nodeBlobToIteratorNode, startKey), nil
 }
 
 func (z *ZkMerkleStateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {

--- a/trie/zk_merkle_trie.go
+++ b/trie/zk_merkle_trie.go
@@ -1,0 +1,72 @@
+package trie
+
+import (
+	zktrie "github.com/kroma-network/zktrie/trie"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+type ZkMerkleTrie struct {
+	*zk.MerkleTree
+	db *Database
+}
+
+func NewZkMerkleTrie(merkleTree *zk.MerkleTree, db *Database) *ZkMerkleTrie {
+	return &ZkMerkleTrie{MerkleTree: merkleTree, db: db}
+}
+
+func (z *ZkMerkleTrie) Hash() common.Hash {
+	hash, _, _ := z.Commit(false)
+	return hash
+}
+
+func (z *ZkMerkleTrie) MustNodeIterator(start []byte) NodeIterator {
+	if it, err := z.NodeIterator(start); err != nil {
+		log.Error("ZkMerkleTrie.MustNodeIterator", "error", err)
+		return nil
+	} else {
+		return it
+	}
+}
+
+func (z *ZkMerkleTrie) NodeIterator(startKey []byte) (NodeIterator, error) {
+	nodeBlobFromTree, nodeBlobToIteratorNode := zkMerkleTreeNodeBlobFunctions(z.db.Get)
+	return newMerkleTreeIterator(z.Hash(), nodeBlobFromTree, nodeBlobToIteratorNode, startKey), nil
+}
+
+func (z *ZkMerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, error) {
+	err := z.ComputeAllNodeHash(func(node zk.TreeNode) error { return z.db.Put(node.Hash()[:], node.CanonicalValue()) })
+	if err != nil {
+		log.Error("Failed to commit zk merkle trie", "err", err)
+	}
+	// There is a bug where root node is saved twice.
+	// It is because of the bottom rawdb.WriteLegacyTrieNode, and we will remove it after checking if it can be removed.
+	rawdb.WriteLegacyTrieNode(z.db.diskdb, common.BytesToHash(z.RootNode().Hash().Bytes()), z.RootNode().CanonicalValue())
+	// Since NodeSet relies directly on mpt, we can't create a NodeSet.
+	// Of course, we might be able to force-fit it by implementing the node interface.
+	// However, NodeSet has been improved in geth, it could be improved to return a NodeSet when a commit is applied.
+	// So let's not do that for the time being.
+	// related geth commit : https://github.com/ethereum/go-ethereum/commit/bbcb5ea37b31c48a59f9aa5fad3fd22233c8a2ae
+	return common.BytesToHash(z.RootNode().Hash().Bytes()), nil, nil
+}
+
+func (z *ZkMerkleTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
+	return z.prove(key, proofDb, func(node zk.TreeNode) error {
+		return proofDb.Put(node.Hash()[:], node.CanonicalValue())
+	})
+}
+
+func (z *ZkMerkleTrie) prove(key []byte, proofDb ethdb.KeyValueWriter, writeNode func(zk.TreeNode) error) error {
+	if _, _, err := z.Commit(false); err != nil {
+		return err
+	} else if err := z.MerkleTree.Prove(key, writeNode); err != nil {
+		return err
+	}
+	// we put this special kv pair in db so we can distinguish the type and make suitable Proof
+	return proofDb.Put(magicHash, zktrie.ProofMagicBytes())
+}

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -186,8 +186,8 @@ func (t *ZkTrie) Copy() *ZkTrie {
 // NodeIterator returns an iterator that returns nodes of the underlying trie. Iteration
 // starts at the key after the given start key.
 func (t *ZkTrie) NodeIterator(start []byte) (NodeIterator, error) {
-	/// FIXME
-	panic("not implemented")
+	nodeBlobFromTree, nodeBlobToIteratorNode := zktrieNodeBlobFunctions(t.ZkTrie)
+	return newMerkleTreeIterator(t.Hash(), nodeBlobFromTree, nodeBlobToIteratorNode, start), nil
 }
 
 // hashKey returns the hash of key as an ephemeral buffer.

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -68,15 +68,19 @@ func NewZkTrie(root common.Hash, db *Database) (*ZkTrie, error) {
 	return &ZkTrie{tr, db}, nil
 }
 
-// Get returns the value for key stored in the trie.
-// The value bytes must not be modified by the caller.
-func (t *ZkTrie) Get(key []byte) []byte {
-	sanityCheckByte32Key(key)
-	res, err := t.TryGet(key)
+func (t *ZkTrie) MustGet(key []byte) []byte {
+	b, err := t.Get(key)
 	if err != nil {
 		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
-	return res
+	return b
+}
+
+// Get returns the value for key stored in the trie.
+// The value bytes must not be modified by the caller.
+func (t *ZkTrie) Get(key []byte) ([]byte, error) {
+	sanityCheckByte32Key(key)
+	return t.TryGet(key)
 }
 
 func (t *ZkTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
@@ -106,8 +110,12 @@ func (t *ZkTrie) UpdateContractCode(_ common.Address, _ common.Hash, _ []byte) e
 //
 // The value bytes must not be modified by the caller while they are
 // stored in the trie.
-func (t *ZkTrie) Update(key, value []byte) {
-	if err := t.TryUpdate(key, value); err != nil {
+func (t *ZkTrie) Update(key, value []byte) error {
+	return t.TryUpdate(key, value)
+}
+
+func (t *ZkTrie) MustUpdate(k, v []byte) {
+	if err := t.TryUpdate(k, v); err != nil {
 		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 }
@@ -131,6 +139,8 @@ func (t *ZkTrie) Delete(key []byte) {
 		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 }
+
+func (t *ZkTrie) MustDelete(key []byte) { t.Delete(key) }
 
 // Delete removes any existing value for key from the trie.
 func (t *ZkTrie) DeleteStorage(_ common.Address, key []byte) error {
@@ -188,6 +198,14 @@ func (t *ZkTrie) Copy() *ZkTrie {
 func (t *ZkTrie) NodeIterator(start []byte) (NodeIterator, error) {
 	nodeBlobFromTree, nodeBlobToIteratorNode := zktrieNodeBlobFunctions(t.ZkTrie)
 	return newMerkleTreeIterator(t.Hash(), nodeBlobFromTree, nodeBlobToIteratorNode, start), nil
+}
+
+func (t *ZkTrie) MustNodeIterator(start []byte) NodeIterator {
+	it, err := t.NodeIterator(start)
+	if err != nil {
+		panic(err)
+	}
+	return it
 }
 
 // hashKey returns the hash of key as an ephemeral buffer.

--- a/trie/zk_trie_test.go
+++ b/trie/zk_trie_test.go
@@ -112,7 +112,7 @@ func TestZktrieGetKey(t *testing.T) {
 	kHash, err := kPreimage.Hash()
 	assert.Nil(t, err)
 
-	if !bytes.Equal(trie.Get(key), value) {
+	if !bytes.Equal(trie.MustGet(key), value) {
 		t.Errorf("Get did not return bar")
 	}
 	if k := trie.GetKey(kHash.Bytes()); !bytes.Equal(k, key) {

--- a/trie/zkproof/writer.go
+++ b/trie/zkproof/writer.go
@@ -442,7 +442,7 @@ func (w *zktrieProofWriter) traceStorageUpdate(addr common.Address, key, value [
 	stateUpdate := [2]*StateStorage{}
 
 	storeKey := zkt.NewByte32FromBytesPaddingZero(common.BytesToHash(key).Bytes())
-	storeValueBefore := trie.Get(storeKey[:])
+	storeValueBefore := trie.MustGet(storeKey[:])
 	storeValue := zkt.NewByte32FromBytes(value)
 	valZero := zkt.Byte32{}
 


### PR DESCRIPTION
# Description

see https://github.com/kroma-network/go-ethereum/issues/44

A stricter implementation would be to use []byte for the key and no key hash in the tree, but i didn't do that this time. 
