### PR TITLE
feat(core): extend trace for supporting type2 tx

### DIFF
--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -339,7 +339,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 	statedb := env.state
 	txs := make([]*types.TransactionData, block.Transactions().Len())
 	for i, tx := range block.Transactions() {
-		txs[i] = types.NewTransactionData(tx, block.NumberU64(), api.backend.ChainConfig())
+		txs[i] = types.NewTransactionData(tx, block.NumberU64(), api.backend.ChainConfig(), block.BaseFee())
 	}
 	blockTrace := &types.BlockTrace{
 		ChainID: api.backend.ChainConfig().ChainID.Uint64(),


### PR DESCRIPTION
extend trace to support type 2 transaction
- A trace includes gas price which equals to effective price
- A trace includes access list when the tx's type is 2