### PR TITLE
fix: fixed deposit tx always incremented nonce by 1

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -102,6 +102,11 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
 
+	nonce := tx.Nonce()
+	if msg.IsDepositTx {
+		nonce = statedb.GetNonce(msg.From)
+	}
+
 	// Apply the transaction to the current state (included in the env).
 	result, err := ApplyMessage(evm, msg, gp)
 	if err != nil {
@@ -137,9 +142,7 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
 
-	nonce := tx.Nonce()
 	if msg.IsDepositTx {
-		nonce = statedb.GetNonce(msg.From)
 		receipt.DepositNonce = &nonce
 	}
 


### PR DESCRIPTION
# Description

The nonce of the deposit transaction is always +1. As a result, if the deposit transaction is a contract deployment transaction, the contract address is being generated incorrectly. As a result, the contract code cannot be retrieved from the L2.
This commit normalizes the nonce. 

The deposit nonce of the receipt and the nonce of the tx will change, but the txhash and receipt hash will be the same, so no hard fork is required.
However, the tx.nonce value will continue to differ by one from previously stored data and geths that are not receiving the patch.

I validated block, tx, and receipt from genesis to 240,000 blocks on the mainnet. I also validated running with data already in place.

Data I validated
- block.hash
- block.parentHash
- deposit tx nonce 1 difference
- receipt.depositNonce 1 difference