### PR TITLE
fix(trie): dont save root hash twice

### DIFF
--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -651,10 +651,10 @@ func TestMerkleTreeIterator(t *testing.T) {
 
 	t.Run("zk merkle tree", func(t *testing.T) {
 		tree, db := makeMerkleTreeWithData(testdata1)
-		expected := db.Len() - 1
+		expected := db.Len()
 		it, _ := tree.NodeIterator(nil)
 		count, leafCount := testIterator(t, db, it)
-		if db.Len()-1 != 0 {
+		if db.Len() != 0 {
 			t.Errorf("db is not empty. remain size %d", db.Len())
 		}
 		if expected != count {

--- a/trie/triedb/hashdb/zktrie_database.go
+++ b/trie/triedb/hashdb/zktrie_database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/VictoriaMetrics/fastcache"
 	zktrie "github.com/kroma-network/zktrie/trie"
+	zkt "github.com/kroma-network/zktrie/types"
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -47,7 +48,7 @@ func NewZk(diskdb ethdb.Database, config *Config) *ZktrieDatabase {
 func (db *ZktrieDatabase) Scheme() string { return rawdb.HashScheme }
 
 func (db *ZktrieDatabase) Initialized(genesisRoot common.Hash) bool {
-	return rawdb.HasLegacyTrieNode(db.diskdb, genesisRoot)
+	return rawdb.HasLegacyTrieNode(db.diskdb, common.BytesToHash(zkt.ReverseByteOrder(genesisRoot[:])))
 }
 
 func (db *ZktrieDatabase) Size() (common.StorageSize, common.StorageSize) {

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -26,7 +26,6 @@ import (
 	zkt "github.com/kroma-network/zktrie/types"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/poseidon"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -171,12 +170,6 @@ func (t *ZkTrie) GetKey(kHashBytes []byte) []byte {
 func (t *ZkTrie) Commit(bool) (common.Hash, *trienode.NodeSet, error) {
 	// in current implementation, every update of trie already writes into database
 	// so Commit does nothing
-	node, err := t.Tree().GetNode(t.Tree().Root())
-	if err != nil {
-		return types.GetEmptyRootHash(true), nil, err
-	}
-
-	rawdb.WriteLegacyTrieNode(t.db.diskdb, t.Hash(), node.Value())
 	return t.Hash(), nil, nil
 }
 


### PR DESCRIPTION
# Description

Previously, there was a bug that prevented the chain from running because the genesis block was not found after the https://github.com/ethereum/go-ethereum/pull/26703 commit. It was solved by reversing the root hash when committing and saving it once more, but this resulted in using about 90 bytes of disk space per block and slowed down the block generation speed by about 30ms. (About 60ms -> 90m for 1 tx block, see related commit https://github.com/kroma-network/go-ethereum/commit/6f7eadcd8ff728061b418dc1e10e77fb4cd32395 )
This commit fixes the above.