### PR TITLE
fix(trie): fix ZkMerkleStateTrie returns invalid proofs

### DIFF
--- a/common/bytes.go
+++ b/common/bytes.go
@@ -149,3 +149,11 @@ func TrimRightZeroes(s []byte) []byte {
 	}
 	return s[:idx]
 }
+
+func ReverseBytes(b []byte) []byte {
+	o := make([]byte, len(b))
+	for i := range b {
+		o[len(b)-1-i] = b[i]
+	}
+	return o
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -756,7 +756,10 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 }
 
 func (s *BlockChainAPI) newStateTrie(id *trie.ID, db *trie.Database) (state.Trie, error) {
-	if s.b.ChainConfig().Zktrie {
+	if db.IsZkStateTrie() {
+		return trie.NewZkMerkleStateTrie(id.Root, db)
+	}
+	if db.IsZk() {
 		return trie.NewZkTrie(id.Root, db)
 	}
 	return trie.NewStateTrie(id, db)

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -640,9 +640,9 @@ func TestMerkleTreeIterator(t *testing.T) {
 	makeMerkleTreeWithData := func(input []kvs) (*ZkMerkleStateTrie, *memorydb.Database) {
 		db := memorydb.New()
 		zdb := NewZkDatabase(rawdb.NewDatabase(db))
-		tree := NewEmptyZkMerkleTrie(zdb)
+		tree := NewEmptyZkMerkleStateTrie(zdb)
 		for _, val := range input {
-			tree.Update(zk.MustNewSecureHash(common.LeftPadBytes([]byte(val.k), 32))[:], common.LeftPadBytes([]byte(val.v), 32))
+			tree.Update(common.LeftPadBytes([]byte(val.k), 32), common.LeftPadBytes([]byte(val.v), 32))
 		}
 		rootHash, _, _ := tree.Commit(false)
 		zdb.Commit(rootHash, true)

--- a/trie/zk/merkle_tree_node.go
+++ b/trie/zk/merkle_tree_node.go
@@ -106,9 +106,6 @@ func (n *ParentNode) Children() [2]TreeNode { return [2]TreeNode{n.childL, n.chi
 type LeafNode struct {
 	Key []byte
 
-	// valueHash is the cache of the hash of valuePreimage to avoid recalculating, only valid for leaf node
-	ValueHash *zkt.Hash
-
 	// ValuePreimage can store at most 256 byte32 as fields (represented by BIG-ENDIAN integer)
 	// and the first 24 can be compressed (each bytes32 consider as 2 fields), in hashing the compressed
 	// elements would be calculated first

--- a/trie/zk_merkle_stack_trie.go
+++ b/trie/zk_merkle_stack_trie.go
@@ -16,7 +16,7 @@ func NewZkStackTrie(writeFn NodeWriteFunc, owner common.Hash) *ZkMerkleStackTrie
 }
 
 func (z *ZkMerkleStackTrie) Update(hash []byte, value []byte) error {
-	return z.MerkleTree.Update(hash, value)
+	return z.MerkleTree.Update(common.ReverseBytes(hash), value)
 }
 
 func (z *ZkMerkleStackTrie) Commit() (h common.Hash, err error) {

--- a/trie/zk_merkle_state_trie.go
+++ b/trie/zk_merkle_state_trie.go
@@ -116,10 +116,10 @@ func (z *ZkMerkleStateTrie) delete(key []byte) error {
 }
 
 func (z *ZkMerkleStateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
-	return z.MerkleTree.Prove(key, func(node zk.TreeNode) error {
+	return z.prove(common.ReverseBytes(key), proofDb, func(node zk.TreeNode) error {
 		value := node.CanonicalValue()
 		if leaf, ok := node.(*zk.LeafNode); ok {
-			if preImage := z.GetKey(zkt.ReverseByteOrder(leaf.Key)); len(preImage) > 0 {
+			if preImage := z.GetKey(common.ReverseBytes(leaf.Key)); len(preImage) > 0 {
 				value[len(value)-1] = byte(len(preImage))
 				value = append(value, preImage[:]...)
 			}


### PR DESCRIPTION
# Description

Get proofapi is responding to the wrong proof because it did not reverse the key when zktrie probe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for reversing byte slices to enhance data manipulation capabilities.

- **Enhancements**
	- Improved state trie creation logic to support different types based on database properties.
	- Enhanced Merkle tree iteration and update mechanisms for better performance and security.
	- Optimized Zero-Knowledge (ZK) Merkle trie operations with key transformation improvements and more efficient hash computations.

- **Refactor**
	- Removed redundant fields and updated methods for clearer, more efficient code in ZK Merkle trie structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->