### PR TITLE
chore: enable canyon upgrade for kroma testnets

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -311,14 +311,20 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			// 	// Apply Base Goerli regolith time
 			// 	config.RegolithTime = &params.BaseGoerliRegolithTime
 			// }
-			// TODO(pangssu): need to hardcode overrides for each chain. (kroma mainnet, kroma sepolia, devnet)
 
-			// NOTE: kroma always post-regolith
+			// [Kroma: START]
 			zero := uint64(0)
 			if config.IsKroma() {
+				// NOTE: kroma always post-regolith
 				config.BedrockBlock = new(big.Int).SetUint64(zero)
 				config.RegolithTime = &zero
+				// Canyon upgrade
+				canyonTime := &params.UpgradeConfigs[config.ChainID.Uint64()].CanyonTime
+				config.CanyonTime = canyonTime
+				config.ShanghaiTime = canyonTime
+				config.Kroma.EIP1559DenominatorCanyon = 250
 			}
+			// [Kroma: END]
 			if overrides != nil && overrides.OverrideCancun != nil {
 				config.CancunTime = overrides.OverrideCancun
 			}
@@ -333,12 +339,14 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				}
 			}
 
+			// [Kroma: START]
 			if overrides != nil && overrides.CircuitParams != nil && overrides.CircuitParams.MaxTxs != nil {
 				config.MaxTxPerBlock = overrides.CircuitParams.MaxTxs
 			}
 			if overrides != nil && overrides.CircuitParams != nil && overrides.CircuitParams.MaxCalldata != nil {
 				config.MaxTxPayloadBytesPerBlock = overrides.CircuitParams.MaxCalldata
 			}
+			// [Kroma: END]
 		}
 	}
 	// Just commit the new block if there is no stored genesis block.

--- a/params/config.go
+++ b/params/config.go
@@ -34,6 +34,7 @@ var (
 const (
 	KromaMainnetChainID = 255
 	KromaSepoliaChainID = 2358
+	KromaDevnetChainID  = 7791
 )
 
 func newUint64(val uint64) *uint64 { return &val }

--- a/params/kroma.go
+++ b/params/kroma.go
@@ -1,0 +1,25 @@
+package params
+
+import (
+	"fmt"
+)
+
+func init() {
+	NetworkNames[fmt.Sprintf("%d", KromaMainnetChainID)] = "KromaMainnet"
+	NetworkNames[fmt.Sprintf("%d", KromaSepoliaChainID)] = "KromaSepolia"
+	NetworkNames[fmt.Sprintf("%d", KromaDevnetChainID)] = "KromaDevnet"
+}
+
+type UpgradeConfig struct {
+	CanyonTime uint64
+}
+
+var UpgradeConfigs = map[uint64]*UpgradeConfig{
+	KromaMainnetChainID: {},
+	KromaSepoliaChainID: {
+		CanyonTime: 1707897600,
+	},
+	KromaDevnetChainID: {
+		CanyonTime: 1707292800,
+	},
+}


### PR DESCRIPTION
# Description

This PR with commits that updated the Canyon upgrade activation time for kroma-devnet and kroma-sepolia.
The activation time for kroma-devnet is `1707292800` and for kroma-sepolia is `1707897600`
At the same time as the Canyon upgrade, the Shanghai upgrade is also activated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for the `Kroma` chain with specific block and time configurations.
	- Introduced new network names and upgrade configurations for different Kroma chains.
- **Refactor**
	- Adjusted time settings for `Canyon` and `Shanghai`.
	- Modified `Cancun` parameters and circuit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->