### PR TITLE
feat: enable Canyon for Kroma mainnet

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -18,7 +18,7 @@ type KromaChainConfig struct {
 
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
-		CanyonTime: nil,
+		CanyonTime: uint64ptr(1708502400),
 	},
 	KromaSepoliaChainID: {
 		CanyonTime: uint64ptr(1707897600),


### PR DESCRIPTION
Enables Canyon upgrade for Kroma mainnet.
- Canyon activation time: `1708502400` (`Wed Feb 21 2024 08:00:00 UTC`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `CanyonTime` field within the blockchain configuration to have specific values for mainnet and testnet environments, enhancing network specificity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->