### PR TITLE
fix: change zktrie iterator key format

### DIFF
--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -859,7 +859,7 @@ func zkMerkleTreeNodeBlobFunctions(findBlobByHash func(key []byte) ([]byte, erro
 				return &merkleTreeIteratorLeafNode{
 					hash: hash,
 					blob: n.Data(),
-					key:  zkt.ReverseByteOrder(n.Key),
+					key:  BytesToZkIteratorKey(n.Key).Bytes(),
 				}, nil
 			}
 			return nil, nil
@@ -899,7 +899,7 @@ func zktrieNodeBlobFunctions(t *zktrie.ZkTrie) (
 				return &merkleTreeIteratorLeafNode{
 					hash: hash,
 					blob: node.Data(),
-					key:  node.NodeKey.Bytes(),
+					key:  BytesToZkIteratorKey(node.NodeKey[:]).Bytes(),
 				}, nil
 			}
 			return nil, nil
@@ -933,6 +933,7 @@ func (it *merkleTreeIterator) seek(path []byte) {
 	if len(path) == 0 {
 		return
 	}
+	path = zk.NewTreePathFromHashBig(common.BytesToHash(path))
 
 	for _, p := range path {
 		if parent, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorParentNode); ok {

--- a/trie/iterator_key.go
+++ b/trie/iterator_key.go
@@ -1,0 +1,26 @@
+package trie
+
+import (
+	zkt "github.com/kroma-network/zktrie/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+// File for defining an iterator key and managing key <-> iterator key conversion functions.
+//
+// NodeIterator.LeafKey must satisfy the following characteristics
+// ```
+// preordertraversal(tree).filter(x -> x is leaf).map(x -> x.leafKey) == sort(leafKeys)
+// ```
+// Since Trie satisfies this condition, functions that utilize it do not require any additional code (e.g. snapsync).
+// However, zktrie does not, so unless we introduce a new key concept, we need to modify the core source code quite a bit.
+// Therefore, we introduced the concept of iteratorKey, which satisfies the above condition, and implemented functions to convert key and iteratorKey.
+
+func BytesToZkIteratorKey(data []byte) common.Hash {
+	return common.BigToHash(zk.NewTreePathFromBytes(data).ToBigInt())
+}
+
+func ZkIteratorKeyToZkHash(key common.Hash) zkt.Hash {
+	return *zk.NewTreePathFromHashBig(key).ToZkHash()
+}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -628,7 +628,7 @@ func TestMerkleTreeIterator(t *testing.T) {
 			db.Delete(zkt.ReverseByteOrder(it.Hash().Bytes()))
 			if it.Leaf() {
 				leafCount++
-				leafPath := zk.NewTreePathFromHash(common.BytesToHash(it.LeafKey()))
+				leafPath := zk.NewTreePathFromHashBig(common.BytesToHash(it.LeafKey()))
 				if !bytes.Equal(it.Path(), leafPath[:len(it.Path())]) {
 					t.Errorf("incorrect tree path. iterator path : %v, leaf path %v", it.Path(), leafPath)
 				}
@@ -670,7 +670,7 @@ func TestMerkleTreeIterator(t *testing.T) {
 		var inputs []*kvs
 		for _, data := range testdata1 {
 			hash := zk.MustNewSecureHash(common.LeftPadBytes([]byte(data.k), 32))
-			inputs = append(inputs, &kvs{k: string(zk.NewTreePathFromZkHash(*hash)), v: data.v})
+			inputs = append(inputs, &kvs{k: string(BytesToZkIteratorKey(hash[:]).Bytes()), v: data.v})
 		}
 		slices.SortFunc(inputs, func(a, b *kvs) int { return bytes.Compare([]byte(a.k), []byte(b.k)) })
 		for idx := 0; idx < len(inputs); idx++ {


### PR DESCRIPTION
The https://github.com/kroma-network/go-ethereum/issues/71 issue was resolved in the snapsync commit, but it was decided to separate it from snapsync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data handling in trie structures with the introduction of a new `data` field for improved efficiency and accuracy.
	- Added new functionalities for iterator key management in trie data structures, facilitating better conversion and handling of keys.
	- Introduced new methods for creating and managing tree paths using big integers, expanding the capabilities for tree path manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->