### PR TITLE
fix: setup payload timeout to 2 seconds

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -234,7 +234,13 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		// Setup the timer for terminating the process if SECONDS_PER_SLOT (12s in
 		// the Mainnet configuration) have passed since the point in time identified
 		// by the timestamp parameter.
-		endTimer := time.NewTimer(time.Second * 12)
+
+		// KROMA has a blocktime of 2 seconds, so we fixed it.
+		endTime := time.Second * 2
+		if w.chainConfig.Kroma == nil {
+			endTime = time.Second * 12
+		}
+		endTimer := time.NewTimer(endTime)
 
 		fullParams := &generateParams{
 			timestamp:   args.Timestamp,


### PR DESCRIPTION
# Description

Modify the hardcoded timeout of 12 seconds to 2 seconds to match the KROMA chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted timer setup logic in mining process to optimize performance based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->