### PR TITLE
feat: enable KromaZKTrie by default

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -190,7 +190,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 
 	cfg.Eth.CircuitParams = new(params.CircuitParams)
-	cfg.Eth.ExperimentalZkTree = ctx.Bool(utils.ExperimentalZkTrie.Name)
+	cfg.Eth.KromaZKTrie = ctx.Bool(utils.KromaZKTrie.Name)
 	if ctx.IsSet(utils.MaxTxsFlag.Name) {
 		maxTxs := ctx.Int(utils.MaxTxsFlag.Name)
 		cfg.Eth.CircuitParams.MaxTxs = &maxTxs

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -157,7 +157,7 @@ var (
 		// [kroma unsupported]
 		// utils.RollupHaltOnIncompatibleProtocolVersionFlag,
 		// utils.RollupSuperchainUpgradesFlag,
-		utils.ExperimentalZkTrie,
+		utils.KromaZKTrie,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1040,6 +1040,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Name:     "KromaZKTrie",
 		Usage:    "use ZkMerkleStateTrie instead of ZkTrie in state.",
 		Category: flags.EthCategory,
+		Value:    true,
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1036,9 +1036,9 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Category: flags.MetricsCategory,
 	}
 
-	ExperimentalZkTrie = &cli.BoolFlag{
-		Name:     "zkstatetrie",
-		Usage:    "use ZkMerkleStateTrie instead of ZkTrie in state. This is an experimental flag.",
+	KromaZKTrie = &cli.BoolFlag{
+		Name:     "KromaZKTrie",
+		Usage:    "use ZkMerkleStateTrie instead of ZkTrie in state.",
 		Category: flags.EthCategory,
 	}
 )

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -151,12 +151,12 @@ type CacheConfig struct {
 	SnapshotNoBuild bool // Whether the background generation is allowed
 	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 
-	ExperimentalZkTrie bool // use ZkMerkleStateTrie instead of ZkTrie
+	KromaZKTrie bool // use ZkMerkleStateTrie instead of ZkTrie
 }
 
 // triedbConfig derives the configures for trie database.
 func (c *CacheConfig) triedbConfig() *trie.Config {
-	config := &trie.Config{Preimages: c.Preimages, ExperimentalZkTrie: c.ExperimentalZkTrie}
+	config := &trie.Config{Preimages: c.Preimages, KromaZKTrie: c.KromaZKTrie}
 	if c.StateScheme == rawdb.HashScheme {
 		config.HashDB = &hashdb.Config{
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -176,7 +176,7 @@ type cachingDB struct {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	if db.triedb.IsZkStateTrie() {
+	if db.triedb.IsKromaZK() {
 		return trie.NewZkMerkleStateTrie(root, db.triedb)
 	}
 	// [Scroll: START]
@@ -197,7 +197,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Address, root common.Hash) (Trie, error) {
-	if db.triedb.IsZkStateTrie() {
+	if db.triedb.IsKromaZK() {
 		return trie.NewZkMerkleStateTrie(root, db.triedb)
 	}
 	// [Scroll: START]

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -208,7 +208,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			// [Scroll: START]
 			MPTWitness: config.MPTWitness,
 			// [Scroll: END]
-			ExperimentalZkTrie: config.ExperimentalZkTree,
+			KromaZKTrie: config.KromaZKTrie,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -190,7 +190,7 @@ type Config struct {
 	// [Scroll: END]
 	CircuitParams *params.CircuitParams
 
-	ExperimentalZkTree bool
+	KromaZKTrie bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -787,7 +787,7 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 }
 
 func (s *BlockChainAPI) newStateTrie(id *trie.ID, db *trie.Database) (state.Trie, error) {
-	if db.IsZkStateTrie() {
+	if db.IsKromaZK() {
 		return trie.NewZkMerkleStateTrie(id.Root, db)
 	}
 	if db.IsZk() {

--- a/trie/database.go
+++ b/trie/database.go
@@ -37,7 +37,7 @@ type Config struct {
 	PathDB    *pathdb.Config // Configs for experimental path-based scheme
 	Zktrie    bool           // use zktrie
 
-	ExperimentalZkTrie bool // use zktree
+	KromaZKTrie bool // use zktree
 }
 
 // HashDefaults represents a config for using hash-based scheme with
@@ -378,19 +378,19 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	return zdb.Get(key)
 }
 
-func (db *Database) IsZk() bool          { return db.config.Zktrie }
-func (db *Database) IsZkStateTrie() bool { return db.config.Zktrie && db.config.ExperimentalZkTrie }
+func (db *Database) IsZk() bool      { return db.config.Zktrie }
+func (db *Database) IsKromaZK() bool { return db.config.Zktrie && db.config.KromaZKTrie }
 
 func (db *Database) SetBackend(isZk bool) {
 	if db.config.Zktrie == isZk {
 		return
 	}
 	db.config = &Config{
-		Preimages:          db.config.Preimages,
-		HashDB:             db.config.HashDB,
-		PathDB:             db.config.PathDB,
-		Zktrie:             isZk,
-		ExperimentalZkTrie: db.config.ExperimentalZkTrie,
+		Preimages:   db.config.Preimages,
+		HashDB:      db.config.HashDB,
+		PathDB:      db.config.PathDB,
+		Zktrie:      isZk,
+		KromaZKTrie: db.config.KromaZKTrie,
 	}
 	if db.config.PathDB != nil {
 		if isZk {

--- a/trie/merkle_trie.go
+++ b/trie/merkle_trie.go
@@ -80,7 +80,7 @@ type MerkleStateTrie interface {
 }
 
 func NewMerkleStateTrie(id *ID, db *Database) (MerkleStateTrie, error) {
-	if db.IsZkStateTrie() {
+	if db.IsKromaZK() {
 		return NewZkMerkleStateTrie(id.Root, db)
 	}
 	if db.IsZk() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `ExperimentalZkTree` to `KromaZKTrie` across various configurations and methods to reflect the new naming convention for ZK state trie usage.
- **New Features**
	- Updated the boolean flag for ZK state trie usage to `KromaZKTrie` with a default value of `true`, enhancing user control over this feature.
- **Documentation**
	- Modified usage descriptions for related flags to better reflect their updated functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->