### PR TITLE
feat: add new transaction type MintTokenTx

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -184,6 +184,11 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		cfg.Eth.OverrideOptimismCanyon = &v
 	}
 
+	if ctx.IsSet(utils.OverrideKromaBurgundy.Name) {
+		v := ctx.Uint64(utils.OverrideKromaBurgundy.Name)
+		cfg.Eth.OverrideKromaBurgundy = &v
+	}
+
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)
 		cfg.Eth.OverrideVerkle = &v

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,6 +70,7 @@ var (
 		utils.OverrideCancun,
 		utils.OverrideVerkle,
 		utils.OverrideOptimismCanyon,
+		utils.OverrideKromaBurgundy,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -270,6 +270,11 @@ var (
 		Usage:    "Manually specify the Optimsim Canyon fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideKromaBurgundy = &flags.BigFlag{
+		Name:     "override.burgundy",
+		Usage:    "Manually specify the Kroma Burgundy fork timestamp, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
 	SyncModeFlag = &flags.TextMarshalerFlag{
 		Name:     "syncmode",
 		Usage:    `Blockchain sync mode ("snap", "full" or "light")`,

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -264,7 +264,8 @@ type ChainOverrides struct {
 	// ApplySuperchainUpgrades bool
 
 	// kroma
-	CircuitParams *params.CircuitParams
+	CircuitParams         *params.CircuitParams
+	OverrideKromaBurgundy *uint64
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -342,6 +343,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				if config.Kroma != nil && config.Kroma.EIP1559DenominatorCanyon == 0 {
 					config.Kroma.EIP1559DenominatorCanyon = 250
 				}
+			}
+			if overrides != nil && overrides.OverrideKromaBurgundy != nil {
+				config.BurgundyTime = overrides.OverrideKromaBurgundy
 			}
 
 			// [Kroma: START]

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -66,7 +66,8 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
-	if tx.Type() == types.DepositTxType {
+	// This is the same for mint token tx as well.
+	if tx.Type() == types.DepositTxType || tx.Type() == types.MintTokenTxType {
 		return core.ErrTxTypeNotSupported
 	}
 	// Ensure transactions not implemented by the calling pool are rejected

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -184,7 +184,7 @@ func NewTransactionData(tx *Transaction, blockNumber uint64, config *params.Chai
 
 	var gasPrice *big.Int
 	switch tx.Type() {
-	case LegacyTxType, AccessListTxType, DepositTxType:
+	case LegacyTxType, AccessListTxType, DepositTxType, MintTokenTxType:
 		gasPrice = tx.GasPrice()
 	case DynamicFeeTxType:
 		if baseFee != nil {

--- a/core/types/mint_token_tx.go
+++ b/core/types/mint_token_tx.go
@@ -1,0 +1,82 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const MintTokenTxType = 0x70
+
+type MintTokenTx struct {
+	From  common.Address  // From is always the mint function caller.
+	To    *common.Address // To always points to the MinterContract address.
+	Gas   uint64
+	Nonce uint64
+	Data  []byte
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *MintTokenTx) copy() TxData {
+	cpy := &MintTokenTx{
+		From:  tx.From,
+		To:    copyAddressPtr(tx.To),
+		Gas:   tx.Gas,
+		Nonce: tx.Nonce,
+		Data:  common.CopyBytes(tx.Data),
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *MintTokenTx) txType() byte           { return MintTokenTxType }
+func (tx *MintTokenTx) chainID() *big.Int      { return common.Big0 }
+func (tx *MintTokenTx) accessList() AccessList { return nil }
+func (tx *MintTokenTx) data() []byte           { return tx.Data }
+func (tx *MintTokenTx) gas() uint64            { return tx.Gas }
+func (tx *MintTokenTx) gasFeeCap() *big.Int    { return new(big.Int) }
+func (tx *MintTokenTx) gasTipCap() *big.Int    { return new(big.Int) }
+func (tx *MintTokenTx) gasPrice() *big.Int     { return new(big.Int) }
+func (tx *MintTokenTx) value() *big.Int        { return common.Big0 }
+func (tx *MintTokenTx) nonce() uint64          { return tx.Nonce }
+func (tx *MintTokenTx) to() *common.Address    { return tx.To }
+
+func (tx *MintTokenTx) effectiveGasPrice(dst *big.Int, _ *big.Int) *big.Int {
+	return dst.Set(new(big.Int))
+}
+
+func (tx *MintTokenTx) effectiveNonce() *uint64 { return nil }
+
+func (tx *MintTokenTx) rawSignatureValues() (v, r, s *big.Int) {
+	return common.Big0, common.Big0, common.Big0
+}
+
+func (tx *MintTokenTx) setSignatureValues(_, _, _, _ *big.Int) {
+	// noop
+}
+
+func (tx *MintTokenTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *MintTokenTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
+}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -293,7 +293,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType:
+	case DynamicFeeTxType, AccessListTxType, BlobTxType, MintTokenTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -428,7 +428,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType:
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, MintTokenTxType:
 		rlp.Encode(w, data)
 	case DepositTxType:
 		if r.DepositReceiptVersion != nil {
@@ -510,7 +510,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			fdivisor := new(big.Float).SetUint64(1_000_000)           // 10**6, i.e. 6 decimals
 			feeScalar := new(big.Float).Quo(fscalar, fdivisor)
 			for i := 0; i < len(rs); i++ {
-				if !txs[i].IsDepositTx() {
+				if !txs[i].IsDepositTx() && !txs[i].IsMintTokenTx() {
 					gas := txs[i].RollupDataGas().DataGas()
 					rs[i].L1GasPrice = l1Basefee
 					// GasUsed reported in receipt should include the overhead

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -209,6 +209,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(BlobTx)
 	case DepositTxType:
 		inner = new(DepositTx)
+	case MintTokenTxType:
+		inner = new(MintTokenTx)
 	default:
 		return nil, ErrTxTypeNotSupported
 	}
@@ -350,6 +352,11 @@ func (tx *Transaction) IsDepositTx() bool {
 	return tx.Type() == DepositTxType
 }
 
+// IsMintTokenTx returns true if the transaction is a mint token tx type.
+func (tx *Transaction) IsMintTokenTx() bool {
+	return tx.Type() == MintTokenTxType
+}
+
 // Cost returns (gas * gasPrice) + (blobGas * blobGasPrice) + value.
 func (tx *Transaction) Cost() *big.Int {
 	total := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
@@ -362,7 +369,7 @@ func (tx *Transaction) Cost() *big.Int {
 
 // RollupDataGas is the amount of gas it takes to confirm the tx on L1 as a rollup
 func (tx *Transaction) RollupDataGas() RollupGasData {
-	if tx.Type() == DepositTxType {
+	if tx.Type() == DepositTxType || tx.Type() == MintTokenTxType {
 		return RollupGasData{}
 	}
 	if v := tx.rollupGas.Load(); v != nil {
@@ -414,7 +421,7 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
-	if tx.Type() == DepositTxType {
+	if tx.Type() == DepositTxType || tx.Type() == MintTokenTxType {
 		return new(big.Int), nil
 	}
 	if baseFee == nil {

--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -5,8 +5,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestTransactionUnmarshalJsonDeposit(t *testing.T) {
@@ -53,6 +54,35 @@ func TestTransactionUnmarshalJsonDepositWithNonce(t *testing.T) {
 	require.Equal(t, uint8(0x7e), got.Type())
 	require.Equal(t, uint64(0xf4240), got.Gas())
 	require.Equal(t, common.HexToHash("0x1234"), got.SourceHash())
+}
+
+func TestTransactionUnmarshalJsonMintToken(t *testing.T) {
+	json := []byte(`{
+		"type": "0x70",
+		"from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0070",
+		"gas": "0xf4240",
+		"nonce": "0x3",
+		"input": "0x1249c58b"
+	}`)
+
+	got := &Transaction{}
+	err := got.UnmarshalJSON(json)
+	require.NoError(t, err, "Failed to unmarshal tx JSON")
+
+	_, ok := got.inner.(*MintTokenTx)
+	require.True(t, ok)
+
+	json, err = got.MarshalJSON()
+	require.NoError(t, err, "Failed to marshal tx JSON")
+
+	got = &Transaction{}
+	err = got.UnmarshalJSON(json)
+	require.NoError(t, err, "Failed to unmarshal tx JSON")
+	require.Equal(t, uint8(0x70), got.Type())
+	require.Equal(t, common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0070"), got.inner.(*MintTokenTx).From)
+	require.Equal(t, uint64(0xf4240), got.Gas())
+	require.Equal(t, uint64(0x3), got.Nonce())
+	require.Equal(t, "1249c58b", common.Bytes2Hex(got.Data()))
 }
 
 func TestTransactionUnmarshalJSON(t *testing.T) {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -264,6 +264,9 @@ func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
 			return tx.inner.(*depositTxWithNonce).From, nil
 		}
 	}
+	if tx.Type() == MintTokenTxType {
+		return tx.inner.(*MintTokenTx).From, nil
+	}
 	if tx.Type() != DynamicFeeTxType {
 		return s.eip2930Signer.Sender(tx)
 	}
@@ -286,6 +289,9 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 	if tx.Type() == DepositTxType {
 		return nil, nil, nil, fmt.Errorf("deposits do not have a signature")
 	}
+	if tx.Type() == MintTokenTxType {
+		return nil, nil, nil, fmt.Errorf("mint token transaction do not have a signature")
+	}
 	txdata, ok := tx.inner.(*DynamicFeeTx)
 	if !ok {
 		return s.eip2930Signer.SignatureValues(tx, sig)
@@ -305,6 +311,9 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 func (s londonSigner) Hash(tx *Transaction) common.Hash {
 	if tx.Type() == DepositTxType {
 		panic("deposits cannot be signed and do not have a signing hash")
+	}
+	if tx.Type() == MintTokenTxType {
+		panic("mint token transaction cannot be signed and do not have a signing hash")
 	}
 	if tx.Type() != DynamicFeeTxType {
 		return s.eip2930Signer.Hash(tx)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -223,6 +223,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideOptimismCanyon != nil {
 		overrides.OverrideOptimismCanyon = config.OverrideOptimismCanyon
 	}
+	if config.OverrideKromaBurgundy != nil {
+		overrides.OverrideKromaBurgundy = config.OverrideKromaBurgundy
+	}
 	if config.CircuitParams != nil && config.CircuitParams.MaxTxs != nil {
 		overrides.CircuitParams.MaxTxs = config.CircuitParams.MaxTxs
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -172,6 +172,8 @@ type Config struct {
 
 	OverrideOptimismCanyon *uint64 `toml:",omitempty"`
 
+	OverrideKromaBurgundy *uint64 `toml:",omitempty"`
+
 	// [kroma unsupported]
 	// ApplySuperchainUpgrades requests the node to load chain-configuration from the superchain-registry.
 	// ApplySuperchainUpgrades bool `toml:",omitempty"`

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -58,8 +58,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon  *uint64 `toml:",omitempty"`
+		OverrideKromaBurgundy   *uint64 `toml:",omitempty"`
 		MPTWitness              int
 		CircuitParams           *params.CircuitParams
+		ExperimentalZkTree      bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -102,8 +104,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.OverrideOptimismCanyon = c.OverrideOptimismCanyon
+	enc.OverrideKromaBurgundy = c.OverrideKromaBurgundy
 	enc.MPTWitness = c.MPTWitness
 	enc.CircuitParams = c.CircuitParams
+	enc.ExperimentalZkTree = c.ExperimentalZkTree
 	return &enc, nil
 }
 
@@ -150,8 +154,10 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		OverrideCancun          *uint64 `toml:",omitempty"`
 		OverrideVerkle          *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon  *uint64 `toml:",omitempty"`
+		OverrideKromaBurgundy   *uint64 `toml:",omitempty"`
 		MPTWitness              *int
 		CircuitParams           *params.CircuitParams
+		ExperimentalZkTree      *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -277,11 +283,17 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.OverrideOptimismCanyon != nil {
 		c.OverrideOptimismCanyon = dec.OverrideOptimismCanyon
 	}
+	if dec.OverrideKromaBurgundy != nil {
+		c.OverrideKromaBurgundy = dec.OverrideKromaBurgundy
+	}
 	if dec.MPTWitness != nil {
 		c.MPTWitness = *dec.MPTWitness
 	}
 	if dec.CircuitParams != nil {
 		c.CircuitParams = dec.CircuitParams
+	}
+	if dec.ExperimentalZkTree != nil {
+		c.ExperimentalZkTree = *dec.ExperimentalZkTree
 	}
 	return nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2068,7 +2068,7 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 
-	if chainConfig.Kroma != nil && !tx.IsDepositTx() {
+	if chainConfig.Kroma != nil && !tx.IsDepositTx() && !tx.IsMintTokenTx() {
 		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -200,6 +200,111 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 	}
 }
 
+func TestNewRPCTransactionMintTokenTx(t *testing.T) {
+	minter := common.HexToAddress("0x2")
+	tx := types.NewTx(&types.MintTokenTx{
+		From: common.HexToAddress("0x1"),
+		To:   &minter,
+		Gas:  1,
+		Data: common.Hex2Bytes("12345678"),
+	})
+	receipt := &types.Receipt{}
+	got := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1234), uint64(1), big.NewInt(0), &params.ChainConfig{}, receipt)
+	// Should provide zero values for unused fields that are required in other transactions
+	require.Equal(t, got.To, tx.To(), "newRPCTransaction().To = %v, want %v", got.To, tx.To())
+	require.Equal(t, got.GasPrice, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
+	require.Equal(t, got.V, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().V = %v, want 0x0", got.V)
+	require.Equal(t, got.R, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().R = %v, want 0x0", got.R)
+	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().S = %v, want 0x0", got.S)
+
+	require.Equal(t, got.Input, (hexutil.Bytes)(tx.Data()), "newRPCTransaction().Input = %v, want %v", got.Input, tx.Data())
+	require.Equal(t, got.Gas, (hexutil.Uint64)(tx.Gas()), "newRPCTransaction().Gas = %v, want %v", got.Gas, tx.Gas())
+}
+
+func TestUnmarshalRpcMintTokenTx(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(tx *RPCTransaction)
+		valid    bool
+	}{
+		{
+			name:     "Unmodified",
+			modifier: func(tx *RPCTransaction) {},
+			valid:    true,
+		},
+		{
+			name: "Zero Values",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = (*hexutil.Big)(common.Big0)
+				tx.R = (*hexutil.Big)(common.Big0)
+				tx.S = (*hexutil.Big)(common.Big0)
+				tx.GasPrice = (*hexutil.Big)(common.Big0)
+			},
+			valid: true,
+		},
+		{
+			name: "Nil Values",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = nil
+				tx.R = nil
+				tx.S = nil
+				tx.GasPrice = nil
+			},
+			valid: true,
+		},
+		{
+			name: "Non-Zero GasPrice",
+			modifier: func(tx *RPCTransaction) {
+				tx.GasPrice = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero V",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero R",
+			modifier: func(tx *RPCTransaction) {
+				tx.R = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero S",
+			modifier: func(tx *RPCTransaction) {
+				tx.S = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			minter := common.HexToAddress("0x2")
+			tx := types.NewTx(&types.MintTokenTx{
+				From: common.HexToAddress("0x1"),
+				To:   &minter,
+				Gas:  1,
+				Data: common.Hex2Bytes("0x12345678"),
+			})
+			rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1234), uint64(1), big.NewInt(0), &params.ChainConfig{}, nil)
+			test.modifier(rpcTx)
+			json, err := json.Marshal(rpcTx)
+			require.NoError(t, err, "marshalling failed: %w", err)
+			parsed := &types.Transaction{}
+			err = parsed.UnmarshalJSON(json)
+			if test.valid {
+				require.NoError(t, err, "unmarshal failed: %w", err)
+			} else {
+				require.Error(t, err, "unmarshal should have failed but did not")
+			}
+		})
+	}
+}
+
 func testTransactionMarshal(t *testing.T, tests []txData, config *params.ChainConfig) {
 	t.Parallel()
 	var (

--- a/params/config.go
+++ b/params/config.go
@@ -340,6 +340,8 @@ type ChainConfig struct {
 	RegolithTime *uint64  `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 	CanyonTime   *uint64  `json:"canyonTime,omitempty"`   // Canyon switch time (nil = no fork, 0 = already on optimism canyon)
 
+	BurgundyTime *uint64 `json:"burgundyTime,omitempty"` // Burgundy switch time (nil = no fork, 0 = already on kroma burgundy)
+
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
 	TerminalTotalDifficulty *big.Int `json:"terminalTotalDifficulty,omitempty"`
@@ -497,6 +499,12 @@ func (c *ChainConfig) Description() string {
 	if c.CanyonTime != nil {
 		banner += fmt.Sprintf(" - Canyon:                      @%-10v\n", *c.CanyonTime)
 	}
+
+	// Create a list of Kroma specific forks
+	banner += "Kroma specific hard forks (timestamp based):\n"
+	if c.BurgundyTime != nil {
+		banner += fmt.Sprintf(" - Burgundy:                    @%-10v\n", *c.BurgundyTime)
+	}
 	return banner
 }
 
@@ -635,6 +643,17 @@ func (c *ChainConfig) IsOptimismPreBedrock(num *big.Int) bool {
 	return c.IsKroma() && !c.IsBedrock(num)
 }
 
+// [Kroma: START]
+
+func (c *ChainConfig) IsBurgundy(time uint64) bool {
+	return isTimestampForked(c.BurgundyTime, time)
+}
+
+func (c *ChainConfig) IsKromaBurgundy(time uint64) bool {
+	return c.IsKroma() && !c.IsBurgundy(time)
+}
+
+// [Kroma: END]
 // [Scroll: START]
 
 // IsValidTxCount returns whether the given block's transaction count is below the limit.
@@ -968,6 +987,7 @@ type Rules struct {
 	IsVerkle                                                bool
 	IsOptimismBedrock, IsOptimismRegolith                   bool
 	IsOptimismCanyon                                        bool
+	IsKromaBurgundy                                         bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -997,6 +1017,8 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsOptimismBedrock:  c.IsOptimismBedrock(num),
 		IsOptimismRegolith: c.IsOptimismRegolith(timestamp),
 		IsOptimismCanyon:   c.IsOptimismCanyon(timestamp),
+		// Kroma
+		IsKromaBurgundy: c.IsKromaBurgundy(timestamp),
 	}
 }
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -13,18 +13,22 @@ import (
 )
 
 type KromaChainConfig struct {
-	CanyonTime *uint64
+	CanyonTime   *uint64
+	BurgundyTime *uint64
 }
 
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
 		CanyonTime: uint64ptr(1708502400),
+		BurgundyTime: nil,
 	},
 	KromaSepoliaChainID: {
-		CanyonTime: uint64ptr(1707897600),
+		CanyonTime:   uint64ptr(1707897600),
+		BurgundyTime: nil,
 	},
 	KromaDevnetChainID: {
-		CanyonTime: uint64ptr(1707292800),
+		CanyonTime:   uint64ptr(1707292800),
+		BurgundyTime: nil,
 	},
 }
 
@@ -84,6 +88,7 @@ func LoadKromaChainConfig(chainID uint64) (*ChainConfig, error) {
 		BedrockBlock:                  common.Big0,
 		RegolithTime:                  &genesisActivation,
 		CanyonTime:                    kromaChainConfig.CanyonTime,
+		BurgundyTime:                  kromaChainConfig.BurgundyTime,
 		TerminalTotalDifficulty:       common.Big0,
 		TerminalTotalDifficultyPassed: true,
 		Ethash:                        nil,

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -19,7 +19,7 @@ type KromaChainConfig struct {
 
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
-		CanyonTime: uint64ptr(1708502400),
+		CanyonTime:   uint64ptr(1708502400),
 		BurgundyTime: nil,
 	},
 	KromaSepoliaChainID: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to manually override the Kroma Burgundy fork timestamp via a new command-line flag, enhancing user control over node configuration.
	- Added support for a new transaction type, `MintTokenTxType`, allowing for minting token transactions within the network.

- **Enhancements**
	- Enhanced transaction processing to accommodate the new `MintTokenTxType`, including adjustments in transaction validation, gas buying, and pre-check routines.
	- Updated RPC processing functions to handle mint token transactions, ensuring compatibility with external interfaces and applications.

- **Configuration**
	- Implemented a new field, `OverrideKromaBurgundy`, across various configurations and genesis settings to facilitate the override of the Kroma Burgundy fork settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->