### PR TITLE
fix: key preimage not saved, invalid format

### DIFF
--- a/trie/zk/merkle_tree_node.go
+++ b/trie/zk/merkle_tree_node.go
@@ -160,7 +160,7 @@ func (n *LeafNode) Hash() *zkt.Hash { return n.hash }
 
 // CanonicalValue [type, Key[0], ..., Key[31], mark[0], ..., mark[3], Data[0], ..., Data[32*len(ValuePreimage)], key preimage len]
 // Leaf node does not provide key preimage, so set the length to 0.
-// If you can provide the key preimage, change the last 0 and add the key preimage afterwards. See ZkMerkleStateTrie.Prove
+// If you can provide the key preimage, change the last 0 and add the key preimage afterwards. See CanonicalValueWithKeyPreimage
 func (n *LeafNode) CanonicalValue() []byte {
 	key := make([]byte, 32)
 	copy(key[:], zkt.ReverseByteOrder(n.Key))
@@ -171,6 +171,18 @@ func (n *LeafNode) CanonicalValue() []byte {
 	buf.Write(n.Data())
 	buf.WriteByte(0) // key preimage len
 	return buf.Bytes()
+}
+
+func (n *LeafNode) CanonicalValueWithKeyPreimage(keyPreimage []byte) []byte {
+	value := n.CanonicalValue()
+	if len(keyPreimage) != 0 {
+		byte32 := &zkt.Byte32{}
+		copy(byte32[:], keyPreimage)
+
+		value[len(value)-1] = byte(len(byte32))
+		value = append(value, byte32[:]...)
+	}
+	return value
 }
 
 func (n *LeafNode) Data() []byte {

--- a/trie/zk_merkle_state_trie.go
+++ b/trie/zk_merkle_state_trie.go
@@ -28,17 +28,18 @@ func NewEmptyZkMerkleStateTrie(db *Database) *ZkMerkleStateTrie {
 }
 
 func newZkMerkleStateTrie(tree *zk.MerkleTree, db *Database) *ZkMerkleStateTrie {
-	trie := NewZkMerkleTrie(tree, db)
+	trie := &ZkMerkleStateTrie{ZkMerkleTrie: NewZkMerkleTrie(tree, db), preimage: db.preimages}
 	trie.logger = log.New("trie", "ZkMerkleStateTrie")
 	trie.transformKey = func(key []byte) ([]byte, error) {
 		sanityCheckByte32Key(key)
-		hash, err := zk.NewSecureHash(key)
+		secureKey, err := zkt.ToSecureKey(key)
 		if err != nil {
 			return nil, err
 		}
-		return hash[:], nil
+		trie.db.UpdatePreimage(key, secureKey)
+		return zkt.NewHashFromBigInt(secureKey)[:], nil
 	}
-	return &ZkMerkleStateTrie{ZkMerkleTrie: trie, preimage: db.preimages}
+	return trie
 }
 
 func (z *ZkMerkleStateTrie) GetKey(kHashBytes []byte) []byte {
@@ -48,10 +49,10 @@ func (z *ZkMerkleStateTrie) GetKey(kHashBytes []byte) []byte {
 		z.logger.Error("failed to GetKey", "error", err)
 		return nil
 	}
-	if z.db.preimages == nil {
+	if z.preimage == nil {
 		return nil
 	}
-	return z.db.preimages.preimage(common.BytesToHash(k.Bytes()))
+	return z.preimage.preimage(common.BytesToHash(k.Bytes()))
 }
 
 func (z *ZkMerkleStateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
@@ -88,14 +89,14 @@ func (z *ZkMerkleStateTrie) DeleteAccount(address common.Address) error       { 
 
 func (z *ZkMerkleStateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	return z.prove(common.ReverseBytes(key), proofDb, func(node zk.TreeNode) error {
-		value := node.CanonicalValue()
 		if leaf, ok := node.(*zk.LeafNode); ok {
-			if preImage := z.GetKey(common.ReverseBytes(leaf.Key)); len(preImage) > 0 {
-				value[len(value)-1] = byte(len(preImage))
-				value = append(value, preImage[:]...)
+			keyPreimage := z.GetKey(common.ReverseBytes(leaf.Key))
+			if len(keyPreimage) == 0 {
+				keyPreimage = key
 			}
+			return proofDb.Put(node.Hash()[:], leaf.CanonicalValueWithKeyPreimage(keyPreimage))
 		}
-		return proofDb.Put(node.Hash()[:], value)
+		return proofDb.Put(node.Hash()[:], node.CanonicalValue())
 	})
 }
 

--- a/trie/zk_merkle_trie_test.go
+++ b/trie/zk_merkle_trie_test.go
@@ -1,0 +1,85 @@
+package trie
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie/testutil"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+func TestProve(t *testing.T) {
+	t.Run("without preimage", func(t *testing.T) {
+		scrolldb, kromadb := NewZkDatabase(rawdb.NewMemoryDatabase()), NewZkDatabase(rawdb.NewMemoryDatabase())
+		root, keys := prepareTrie(t, scrolldb, kromadb)
+		assertProof(t, must(NewZkTrie(root, scrolldb)), must(NewZkMerkleStateTrie(root, kromadb)), keys)
+	})
+
+	t.Run("with preimage", func(t *testing.T) {
+		config := ZkHashDefaults
+		config.Preimages = true
+		scrolldb, kromadb := NewDatabase(rawdb.NewMemoryDatabase(), config), NewDatabase(rawdb.NewMemoryDatabase(), config)
+		root, keys := prepareTrie(t, scrolldb, kromadb)
+		assertProof(t, must(NewZkTrie(root, scrolldb)), must(NewZkMerkleStateTrie(root, kromadb)), keys)
+	})
+}
+
+func assertProof(t *testing.T, scrollTrie *ZkTrie, kromaTrie *ZkMerkleStateTrie, keys []common.Hash) {
+	for _, hash := range keys {
+		scrollDB := rawdb.NewMemoryDatabase()
+		assert.NoError(t, scrollTrie.Prove(hash.Bytes(), scrollDB))
+
+		kromaDB := rawdb.NewMemoryDatabase()
+		assert.NoError(t, kromaTrie.Prove(hash.Bytes(), kromaDB))
+
+		for scrollIt, kromaIt := scrollDB.NewIterator(nil, nil), kromaDB.NewIterator(nil, nil); ; {
+			scrollNext, kromaNext := scrollIt.Next(), kromaIt.Next()
+			assert.Equal(t, scrollNext, kromaNext)
+			assert.Equal(t, scrollIt.Value(), kromaIt.Value())
+			if !scrollNext {
+				break
+			}
+		}
+	}
+}
+
+func prepareTrie(t *testing.T, scrollDB *Database, kromaDB *Database) (rootHash common.Hash, keys []common.Hash) {
+	scrollTrie, _ := NewZkTrie(common.Hash{}, scrollDB)
+	kromaTrie := NewEmptyZkMerkleStateTrie(kromaDB)
+
+	keyHashes := make([]common.Hash, 100)
+	for i := 0; i < len(keyHashes); i++ {
+		address, account := newRandomStateAccount()
+		keyHashes[i] = common.BytesToHash(zk.MustNewSecureHash(address.Bytes()).Bytes())
+		assert.NoError(t, scrollTrie.UpdateAccount(address, account))
+		assert.NoError(t, kromaTrie.UpdateAccount(address, account))
+	}
+	scrollRoot, _, _ := scrollTrie.Commit(false)
+	kromaRoot, _, _ := kromaTrie.Commit(false)
+	assert.Equal(t, scrollRoot, kromaRoot)
+	assert.NoError(t, scrollDB.Commit(scrollRoot, false))
+	assert.NoError(t, kromaDB.Commit(kromaRoot, false))
+	return scrollRoot, keyHashes
+}
+
+func newRandomStateAccount() (common.Address, *types.StateAccount) {
+	return testutil.RandomAddress(), &types.StateAccount{
+		Nonce:    uint64(rand.Uint32()),
+		Balance:  big.NewInt(int64(rand.Uint32())),
+		Root:     common.BigToHash(big.NewInt(int64(rand.Uint32()))),
+		CodeHash: common.BigToHash(big.NewInt(int64(rand.Uint32()))).Bytes(),
+	}
+}
+
+func must[R any](r R, err error) R {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}


### PR DESCRIPTION
# Description

This PR fixes below issues.

1. The key preimage was not being saved.
2. The key preimage format was incorrect when gettingProof.