### PR TITLE
chore: set Ecotone time for Kroma sepolia

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -23,7 +23,7 @@ var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	},
 	KromaSepoliaChainID: {
 		CanyonTime:  uint64ptr(1707897600),
-		EcotoneTime: nil,
+		EcotoneTime: uint64ptr(1713340800),
 	},
 	KromaDevnetChainID: {
 		CanyonTime:  uint64ptr(1707292800),


### PR DESCRIPTION
Set Ecotone activation time for Kroma sepolia.
The activation time is `Wed Apr 17 2024 08:00:00`(unix timestamp `1713340800`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the `EcotoneTime` setting to a specific value for better chain configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->