### PR TITLE
chore: set Ecotone time for Kroma mainnet

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -19,7 +19,7 @@ type KromaChainConfig struct {
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
 		CanyonTime:  uint64ptr(1708502400),
-		EcotoneTime: nil,
+		EcotoneTime: uint64ptr(1713772800),
 	},
 	KromaSepoliaChainID: {
 		CanyonTime:  uint64ptr(1707897600),


### PR DESCRIPTION
Set Ecotone activation time for Kroma mainnet.
The activation time is Mon `Apr 22 2024 08:00:00`(unix timestamp `1713772800`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the configuration for the main network to ensure accurate timing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->