### PR TITLE
chore: change Ecotone time for Kroma mainnet

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -19,7 +19,7 @@ type KromaChainConfig struct {
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
 		CanyonTime:  uint64ptr(1708502400),
-		EcotoneTime: uint64ptr(1713772800),
+		EcotoneTime: uint64ptr(1713772801),
 	},
 	KromaSepoliaChainID: {
 		CanyonTime:  uint64ptr(1707897600),


### PR DESCRIPTION
The timestamp for Kroma mainnet should be odd number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the timing configuration in the chain settings to ensure synchronization accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->