### PR TITLE
Revert "feat: add overhead and l1feescalar proofs to trace (#94)"

### DIFF
--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -17,7 +17,6 @@
 package vm
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -502,16 +501,6 @@ func (l *StructLogger) MaybeAddFeeRecipientsToStatesAffected(tx *types.Transacti
 		l.statesAffected[params.KromaProtocolVault] = struct{}{}
 		l.statesAffected[params.KromaProposerRewardVault] = struct{}{}
 		l.statesAffected[params.KromaValidatorRewardVault] = struct{}{}
-	}
-}
-
-func (l *StructLogger) MaybeAddL1BlockInfo(tx *types.Transaction) {
-	if tx.To() == nil {
-		return
-	}
-	if contractAddress := *tx.To(); bytes.Equal(contractAddress[:], types.L1BlockAddr[:]) {
-		l.storage[contractAddress][types.OverheadSlot] = l.env.StateDB.GetState(contractAddress, types.OverheadSlot)
-		l.storage[contractAddress][types.ScalarSlot] = l.env.StateDB.GetState(contractAddress, types.ScalarSlot)
 	}
 }
 

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -262,7 +262,6 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 	}
 
 	tracer.MaybeAddFeeRecipientsToStatesAffected(tx)
-	tracer.MaybeAddL1BlockInfo(tx)
 
 	// merge required proof data
 	proofAccounts := tracer.UpdatedAccounts()


### PR DESCRIPTION
# Description

Since zkevm-circuits now supports Ecotone fee collection logic, this feature becomes redundant.

This should be merged after https://github.com/kroma-network/zkevm-circuits/pull/39 and https://github.com/kroma-network/kroma-prover/pull/25.