### PR TITLE
feat: state migration and transition from ZKT to MPT

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/naoina/toml"
+	"github.com/urfave/cli/v2"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/external"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -44,8 +47,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/naoina/toml"
-	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -206,6 +207,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	cfg.Eth.CircuitParams = new(params.CircuitParams)
 	cfg.Eth.KromaZKTrie = ctx.Bool(utils.KromaZKTrie.Name)
+	cfg.Eth.DisableMPTMigration = ctx.Bool(utils.DisableMPTMigrationFlag.Name)
 	if ctx.IsSet(utils.MaxTxsFlag.Name) {
 		maxTxs := ctx.Int(utils.MaxTxsFlag.Name)
 		cfg.Eth.CircuitParams.MaxTxs = &maxTxs

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -192,6 +192,12 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverrideOptimismInterop.Name)
 		cfg.Eth.OverrideOptimismInterop = &v
 	}
+	// [Kroma: ZKT to MPT]
+	if ctx.IsSet(utils.OverrideKromaMPT.Name) {
+		v := ctx.Uint64(utils.OverrideKromaMPT.Name)
+		cfg.Eth.OverrideKromaMPT = &v
+	}
+	// [Kroma: END]
 
 	if ctx.IsSet(utils.OverrideVerkle.Name) {
 		v := ctx.Uint64(utils.OverrideVerkle.Name)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,7 @@ var (
 		utils.RollupSuperchainUpgradesFlag,
 		*/
 		utils.KromaZKTrie,
+		utils.DisableMPTMigrationFlag,
 		configFileFlag,
 		utils.LogDebugFlag,
 		utils.LogBacktraceAtFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -72,6 +72,7 @@ var (
 		utils.OverrideOptimismCanyon,
 		utils.OverrideOptimismEcotone,
 		utils.OverrideOptimismInterop,
+		utils.OverrideKromaMPT,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,
@@ -152,8 +153,10 @@ var (
 		utils.GpoMinSuggestedPriorityFeeFlag,
 		/* [kroma unsupported]
 		utils.RollupSequencerHTTPFlag,
+		*/
 		utils.RollupHistoricalRPCFlag,
 		utils.RollupHistoricalRPCTimeoutFlag,
+		/* [kroma unsupported]
 		utils.RollupDisableTxPoolGossipFlag,
 		*/
 		utils.RollupComputePendingBlock,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -278,6 +278,13 @@ var (
 		Usage:    "Manually specify the Optimsim Interop feature-set fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	// [Kroma: ZKT to MPT]
+	OverrideKromaMPT = &cli.Uint64Flag{
+		Name:     "override.mpt",
+		Usage:    "Manually specify the Kroma mpt transition timestamp, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
+	// [Kroma: END]
 	SyncModeFlag = &flags.TextMarshalerFlag{
 		Name:     "syncmode",
 		Usage:    `Blockchain sync mode ("snap" or "full")`,
@@ -865,6 +872,7 @@ var (
 		Value:    ethconfig.Defaults.GPO.MinSuggestedPriorityFee.Int64(),
 		Category: flags.GasPriceCategory,
 	}
+
 	/* [kroma unsupported]
 	// Rollup Flags
 	RollupSequencerHTTPFlag = &cli.StringFlag{
@@ -872,6 +880,7 @@ var (
 		Usage:    "HTTP endpoint for the sequencer mempool",
 		Category: flags.RollupCategory,
 	}
+	*/
 
 	RollupHistoricalRPCFlag = &cli.StringFlag{
 		Name:     "rollup.historicalrpc",
@@ -886,6 +895,7 @@ var (
 		Category: flags.RollupCategory,
 	}
 
+	/* [kroma unsupported]
 	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
 		Name:     "rollup.disabletxpoolgossip",
 		Usage:    "Disable transaction pool gossip.",
@@ -1866,16 +1876,16 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
 	}
-	/* [kroma unsupported]
-	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
-	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
-		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
-	}
 	if ctx.IsSet(RollupHistoricalRPCFlag.Name) {
 		cfg.RollupHistoricalRPC = ctx.String(RollupHistoricalRPCFlag.Name)
 	}
 	if ctx.IsSet(RollupHistoricalRPCTimeoutFlag.Name) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
+	}
+	/* [kroma unsupported]
+	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
+	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
+		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1028,6 +1028,12 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Category: flags.EthCategory,
 		Value:    true,
 	}
+	DisableMPTMigrationFlag = &cli.BoolFlag{
+		Name:     "kroma.migration.disable",
+		Usage:    "Disable migration to switch from ZKTrie to Merkle Patricia Tree",
+		Category: flags.EthCategory,
+		Value:    false,
+	}
 )
 
 var (

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -484,7 +484,11 @@ func IsTTDReached(chain consensus.ChainHeaderReader, parentHash common.Hash, par
 	if cfg := chain.Config(); cfg.Kroma != nil {
 		// If OP-Stack then bedrock activation number determines when TTD (eth Merge) has been reached.
 		// Note: some tests/utils will set parentNumber == max_uint64 as "parent" of the genesis block, this is fine.
-		return cfg.IsBedrock(new(big.Int).SetUint64(parentNumber + 1)), nil
+		// return cfg.IsBedrock(new(big.Int).SetUint64(parentNumber + 1)), nil
+		// [Kroma: ZKT to MPT]
+		// Since Kroma was started post-Merge, it always returns true.
+		return true, nil
+		// [Kroma: END]
 	}
 	if chain.Config().TerminalTotalDifficulty == nil {
 		return false, nil

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2602,3 +2602,8 @@ func (bc *BlockChain) SetTrieFlushInterval(interval time.Duration) {
 func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
+
+// GetMigratedRef returns a reference to the migrated state during ZKT to MPT transition.
+func (bc *BlockChain) GetMigratedRef() *MigratedRef {
+	return NewMigratedRef(bc.db)
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/common/mclock"
@@ -51,7 +53,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie/triedb/hashdb"
 	"github.com/ethereum/go-ethereum/trie/triedb/pathdb"
 	"github.com/ethereum/go-ethereum/trie/zkproof"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -350,6 +351,14 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	// Make sure the state associated with the block is available, or log out
 	// if there is no available state, waiting for state sync.
 	head := bc.CurrentBlock()
+
+	// [Kroma: ZKT to MPT]
+	if chainConfig.IsKromaMPT(head.Time) {
+		bc.chainConfig.Zktrie = false
+		bc.triedb.SetBackend(false)
+	}
+	// [Kroma: END]
+
 	if !bc.HasState(head.Root) {
 		if head.Number.Uint64() == 0 {
 			// The genesis state is missing, which is only possible in the path-based
@@ -1788,7 +1797,20 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		if parent == nil {
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
-		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
+		// [Kroma: ZKT to MPT]
+		var statedb *state.StateDB
+		if bc.Config().IsKromaMPTActivationBlock(block.Time()) {
+			migratedRef := NewMigratedRef(bc.db)
+			if migratedRef.Root() == (common.Hash{}) || migratedRef.BlockNumber() != parent.Number.Uint64() {
+				return it.index, errors.New("cannot find migrated reference")
+			}
+			bc.Config().Zktrie = false
+			bc.TrieDB().SetBackend(false)
+			statedb, err = state.New(migratedRef.Root(), bc.stateCache, bc.snaps)
+		} else {
+			statedb, err = state.New(parent.Root, bc.stateCache, bc.snaps)
+		}
+		// [Kroma: END]
 		if err != nil {
 			return it.index, err
 		}

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -279,6 +279,16 @@ func (bc *BlockChain) GetTd(hash common.Hash, number uint64) *big.Int {
 // HasState checks if state trie is fully present in the database or not.
 func (bc *BlockChain) HasState(hash common.Hash) bool {
 	_, err := bc.stateCache.OpenTrie(hash)
+	// [Kroma: ZKT to MPT]
+	if err != nil && bc.chainConfig.IsKroma() {
+		isZk := bc.chainConfig.Zktrie
+		bc.chainConfig.Zktrie = !isZk
+		bc.triedb.SetBackend(!isZk)
+		_, err = bc.stateCache.OpenTrie(hash)
+		bc.chainConfig.Zktrie = isZk
+		bc.triedb.SetBackend(isZk)
+	}
+	// [Kroma: END]
 	return err == nil
 }
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3118,6 +3118,58 @@ func TestSelfDestructDisabled(t *testing.T) {
 
 // [Scroll: END]
 
+// [Kroma: START]
+// TestSelfDestructReEnabled
+func TestSelfDestructReEnabled(t *testing.T) {
+	var (
+		// Generate a canonical chain to act as the main dataset
+		engine = ethash.NewFaker()
+		db     = rawdb.NewMemoryDatabase()
+		// A sender who makes transactions, has some funds
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+
+		aa        = common.HexToAddress("0x7217d81b76bdd8707601e959454e3d776aee5f43")
+		aaStorage = make(map[common.Hash]common.Hash)          // Initial storage in AA
+		aaCode    = []byte{byte(vm.PC), byte(vm.SELFDESTRUCT)} // Code for AA (simple selfdestruct)
+	)
+
+	// Enable KromaMPT
+	zero := uint64(0)
+	params.KromaTestConfig.KromaMPTTime = &zero
+	gspec := &Genesis{
+		Config: params.KromaTestConfig,
+		Alloc: GenesisAlloc{
+			address: {Balance: funds},
+			// The address 0xAAAAA selfdestructs if called
+			aa: {
+				// Code needs to just selfdestruct
+				Code:    aaCode,
+				Nonce:   1,
+				Balance: big.NewInt(0),
+				Storage: aaStorage,
+			},
+		},
+	}
+	gspec.Config.KromaMPTTime = &zero
+	genesis := gspec.MustCommit(db, trie.NewDatabase(db, trie.GetHashDefaults(gspec.Config.Zktrie)))
+
+	_, receipts := GenerateChain(params.KromaTestConfig, genesis, engine, db, 1, func(i int, b *BlockGen) {
+		b.SetCoinbase(common.Address{1})
+		// One transaction to AA, to kill it
+		tx, _ := types.SignTx(types.NewTransaction(0, aa,
+			big.NewInt(0), 50000, b.header.BaseFee, nil), types.HomesteadSigner{}, key)
+		b.AddTx(tx)
+	})
+
+	if receipts[0][0].Status != types.ReceiptStatusSuccessful {
+		t.Fatalf("Expected transaction triggering SELFDESTRUCT to success")
+	}
+}
+
+// [Kroma: END]
+
 // TestDeleteCreateRevert tests a weird state transition corner case that we hit
 // while changing the internals of statedb. The workflow is that a contract is
 // self destructed, then in a followup transaction (but same block) it's created

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -276,7 +276,8 @@ type ChainOverrides struct {
 	OverrideOptimismInterop *uint64
 
 	// kroma
-	CircuitParams *params.CircuitParams
+	CircuitParams    *params.CircuitParams
+	OverrideKromaMPT *uint64
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -316,7 +317,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 
 				// NOTE: kroma always post-regolith
 				zero := uint64(0)
-				config.BedrockBlock = new(big.Int).SetUint64(zero)
+				if config.BedrockBlock == nil {
+					config.BedrockBlock = new(big.Int).SetUint64(zero)
+				}
 				config.RegolithTime = &zero
 			}
 			if overrides != nil && overrides.CircuitParams != nil && overrides.CircuitParams.MaxTxs != nil {
@@ -324,6 +327,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			}
 			if overrides != nil && overrides.CircuitParams != nil && overrides.CircuitParams.MaxCalldata != nil {
 				config.MaxTxPayloadBytesPerBlock = overrides.CircuitParams.MaxCalldata
+			}
+			if overrides != nil && overrides.OverrideKromaMPT != nil {
+				config.KromaMPTTime = overrides.OverrideKromaMPT
 			}
 			// [Kroma: END]
 

--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+var ErrHaltOnStateTransition = errors.New("since migration is disabled, transitioning to MPT is not possible")
+
+type MigratedRef struct {
+	db ethdb.Database
+	mu sync.Mutex
+
+	root   common.Hash
+	number uint64
+}
+
+func NewMigratedRef(db ethdb.Database) *MigratedRef {
+	ref := &MigratedRef{db: db}
+	if b, _ := db.Get([]byte("migration-root")); len(b) > 0 {
+		ref.root = common.BytesToHash(b)
+	}
+	if b, _ := db.Get([]byte("migration-number")); len(b) > 0 {
+		ref.number = hexutil.MustDecodeUint64(string(b))
+	}
+	return ref
+}
+
+func (mr *MigratedRef) Update(root common.Hash, number uint64) error {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	if err := mr.db.Put([]byte("migration-root"), root.Bytes()); err != nil {
+		return fmt.Errorf("failed to update migrated state root: %w", err)
+	}
+	if err := mr.db.Put([]byte("migration-number"), []byte(hexutil.EncodeUint64(number))); err != nil {
+		return fmt.Errorf("failed to update migrated block number: %w", err)
+	}
+	mr.root = root
+	mr.number = number
+	return nil
+}
+
+func (mr *MigratedRef) Root() common.Hash {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	return mr.root
+}
+
+func (mr *MigratedRef) BlockNumber() uint64 {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+	return mr.number
+}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -356,6 +356,14 @@ func (tx *Transaction) IsDepositTx() bool {
 	return tx.Type() == DepositTxType
 }
 
+// IsSystemTx returns true for deposits that are system transactions. These transactions
+// are executed in an unmetered environment & do not contribute to the block gas limit.
+func (tx *Transaction) IsSystemTx() bool {
+	// [Kroma: START]
+	return false
+	// [Kroma: END]
+}
+
 // Cost returns (gas * gasPrice) + (blobGas * blobGasPrice) + value.
 func (tx *Transaction) Cost() *big.Int {
 	total := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,11 +17,12 @@
 package vm
 
 import (
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 )
 
 func opAdd(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
@@ -817,6 +818,12 @@ func opStop(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 }
 
 func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	// [Kroma: START]
+	// NOTE: Since zkEVM cannot prove this opcode, it is disabled before KromaMPTTime.
+	if interpreter.evm.chainConfig.IsPreKromaMPT(interpreter.evm.Context.Time) {
+		return opUndefined(pc, interpreter, scope)
+	}
+	// [Kroma: END]
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}
@@ -832,6 +839,12 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 }
 
 func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	// [Kroma: START]
+	// NOTE: Since zkEVM cannot prove this opcode, it is disabled before KromaMPTTime.
+	if interpreter.evm.chainConfig.IsPreKromaMPT(interpreter.evm.Context.Time) {
+		return opUndefined(pc, interpreter, scope)
+	}
+	// [Kroma: END]
 	if interpreter.readOnly {
 		return nil, ErrWriteProtection
 	}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -86,16 +86,6 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	default:
 		table = &frontierInstructionSet
 	}
-	// [Scroll: START]
-	// NOTE: SELFDESTRUCT is disabled in Kroma. This is not meant to disable
-	// forever this opcode. Once zkEVM spec can cover it, we need to re-enable it.
-	if evm.chainConfig.Zktrie {
-		table[SELFDESTRUCT] = &operation{
-			execute:  opUndefined,
-			maxStack: maxStack(0, 0),
-		}
-	}
-	// [Scroll: END]
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -428,6 +428,10 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
 
+func (b *EthAPIBackend) HistoricalRPCService() *rpc.Client {
+	return b.eth.historicalRPCService
+}
+
 func (b *EthAPIBackend) Genesis() *types.Block {
 	return b.eth.blockchain.Genesis()
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -18,6 +18,7 @@
 package eth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -78,8 +79,8 @@ type Ethereum struct {
 
 	/* [kroma unsupported]
 	seqRPCService        *rpc.Client
-	historicalRPCService *rpc.Client
 	*/
+	historicalRPCService *rpc.Client
 
 	// DB interfaces
 	chainDb ethdb.Database // Block chain database
@@ -243,6 +244,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	/* [kroma unsupported]
 	overrides.ApplySuperchainUpgrades = config.ApplySuperchainUpgrades
 	*/
+	// [Kroma: ZKT to MPT]
+	if config.OverrideKromaMPT != nil {
+		overrides.OverrideKromaMPT = config.OverrideKromaMPT
+	}
+	// [Kroma: END]
+
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err
@@ -330,6 +337,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 		eth.seqRPCService = client
 	}
+	*/
 
 	if config.RollupHistoricalRPC != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), config.RollupHistoricalRPCTimeout)
@@ -340,7 +348,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 		eth.historicalRPCService = client
 	}
-	*/
 	// Start the RPC service
 	eth.netRPCService = ethapi.NewNetAPI(eth.p2pServer, networkID)
 
@@ -613,11 +620,10 @@ func (s *Ethereum) Stop() error {
 	if s.seqRPCService != nil {
 		s.seqRPCService.Close()
 	}
+	*/
 	if s.historicalRPCService != nil {
 		s.historicalRPCService.Close()
 	}
-	*/
-
 	// Clean shutdown marker as the last thing before closing db
 	s.shutdownTracker.Stop()
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -187,6 +187,7 @@ type Config struct {
 
 	KromaZKTrie         bool
 	OverrideKromaMPT    *uint64 `toml:",omitempty"`
+	DisableMPTMigration bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -171,8 +171,10 @@ type Config struct {
 	ApplySuperchainUpgrades bool `toml:",omitempty"`
 
 	RollupSequencerHTTP                     string
-	RollupHistoricalRPC                     string
-	RollupHistoricalRPCTimeout              time.Duration
+	*/
+	RollupHistoricalRPC        string
+	RollupHistoricalRPCTimeout time.Duration
+	/* [kroma unsupported]
 	RollupDisableTxPoolGossip               bool
 	RollupDisableTxPoolAdmission            bool
 	RollupHaltOnIncompatibleProtocolVersion string
@@ -183,7 +185,8 @@ type Config struct {
 	// [Scroll: END]
 	CircuitParams *params.CircuitParams
 
-	KromaZKTrie bool
+	KromaZKTrie         bool
+	OverrideKromaMPT    *uint64 `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -18,51 +18,55 @@ import (
 // MarshalTOML marshals as TOML.
 func (c Config) MarshalTOML() (interface{}, error) {
 	type Config struct {
-		Genesis                 *core.Genesis `toml:",omitempty"`
-		NetworkId               uint64
-		SyncMode                downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               bool
-		NoPrefetch              bool
-		TxLookupLimit           uint64                 `toml:",omitempty"`
-		TransactionHistory      uint64                 `toml:",omitempty"`
-		StateHistory            uint64                 `toml:",omitempty"`
-		StateScheme             string                 `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               int                    `toml:",omitempty"`
-		LightIngress            int                    `toml:",omitempty"`
-		LightEgress             int                    `toml:",omitempty"`
-		LightPeers              int                    `toml:",omitempty"`
-		LightNoPrune            bool                   `toml:",omitempty"`
-		LightNoSyncServe        bool                   `toml:",omitempty"`
-		SkipBcVersionCheck      bool                   `toml:"-"`
-		DatabaseHandles         int                    `toml:"-"`
-		DatabaseCache           int
-		DatabaseFreezer         string
-		TrieCleanCache          int
-		TrieDirtyCache          int
-		TrieTimeout             time.Duration
-		SnapshotCache           int
-		Preimages               bool
-		FilterLogCacheSize      int
-		Miner                   miner.Config
-		TxPool                  legacypool.Config
-		BlobPool                blobpool.Config
-		GPO                     gasprice.Config
-		EnablePreimageRecording bool
-		DocRoot                 string `toml:"-"`
-		RPCGasCap               uint64
-		RPCEVMTimeout           time.Duration
-		RPCTxFeeCap             float64
-		OverrideCancun          *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
-		OverrideOptimismCanyon  *uint64 `toml:",omitempty"`
-		OverrideOptimismEcotone *uint64 `toml:",omitempty"`
-		OverrideOptimismInterop *uint64 `toml:",omitempty"`
-		MPTWitness              int
-		CircuitParams           *params.CircuitParams
-		KromaZKTrie             bool
+		Genesis                    *core.Genesis `toml:",omitempty"`
+		NetworkId                  uint64
+		SyncMode                   downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  bool
+		NoPrefetch                 bool
+		TxLookupLimit              uint64                 `toml:",omitempty"`
+		TransactionHistory         uint64                 `toml:",omitempty"`
+		StateHistory               uint64                 `toml:",omitempty"`
+		StateScheme                string                 `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  int                    `toml:",omitempty"`
+		LightIngress               int                    `toml:",omitempty"`
+		LightEgress                int                    `toml:",omitempty"`
+		LightPeers                 int                    `toml:",omitempty"`
+		LightNoPrune               bool                   `toml:",omitempty"`
+		LightNoSyncServe           bool                   `toml:",omitempty"`
+		SkipBcVersionCheck         bool                   `toml:"-"`
+		DatabaseHandles            int                    `toml:"-"`
+		DatabaseCache              int
+		DatabaseFreezer            string
+		TrieCleanCache             int
+		TrieDirtyCache             int
+		TrieTimeout                time.Duration
+		SnapshotCache              int
+		Preimages                  bool
+		FilterLogCacheSize         int
+		Miner                      miner.Config
+		TxPool                     legacypool.Config
+		BlobPool                   blobpool.Config
+		GPO                        gasprice.Config
+		EnablePreimageRecording    bool
+		DocRoot                    string `toml:"-"`
+		RPCGasCap                  uint64
+		RPCEVMTimeout              time.Duration
+		RPCTxFeeCap                float64
+		OverrideCancun             *uint64 `toml:",omitempty"`
+		OverrideVerkle             *uint64 `toml:",omitempty"`
+		OverrideOptimismCanyon     *uint64 `toml:",omitempty"`
+		OverrideOptimismEcotone    *uint64 `toml:",omitempty"`
+		OverrideOptimismInterop    *uint64 `toml:",omitempty"`
+		OverrideKromaMPT           *uint64 `toml:",omitempty"`
+		DisableMPTMigration        bool
+		RollupHistoricalRPC        string
+		RollupHistoricalRPCTimeout time.Duration
+		MPTWitness                 int
+		CircuitParams              *params.CircuitParams
+		KromaZKTrie                bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -107,6 +111,10 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideOptimismCanyon = c.OverrideOptimismCanyon
 	enc.OverrideOptimismEcotone = c.OverrideOptimismEcotone
 	enc.OverrideOptimismInterop = c.OverrideOptimismInterop
+	enc.OverrideKromaMPT = c.OverrideKromaMPT
+	enc.DisableMPTMigration = c.DisableMPTMigration
+	enc.RollupHistoricalRPC = c.RollupHistoricalRPC
+	enc.RollupHistoricalRPCTimeout = c.RollupHistoricalRPCTimeout
 	enc.MPTWitness = c.MPTWitness
 	enc.CircuitParams = c.CircuitParams
 	enc.KromaZKTrie = c.KromaZKTrie
@@ -116,51 +124,55 @@ func (c Config) MarshalTOML() (interface{}, error) {
 // UnmarshalTOML unmarshals from TOML.
 func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type Config struct {
-		Genesis                 *core.Genesis `toml:",omitempty"`
-		NetworkId               *uint64
-		SyncMode                *downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               *bool
-		NoPrefetch              *bool
-		TxLookupLimit           *uint64                `toml:",omitempty"`
-		TransactionHistory      *uint64                `toml:",omitempty"`
-		StateHistory            *uint64                `toml:",omitempty"`
-		StateScheme             *string                `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               *int                   `toml:",omitempty"`
-		LightIngress            *int                   `toml:",omitempty"`
-		LightEgress             *int                   `toml:",omitempty"`
-		LightPeers              *int                   `toml:",omitempty"`
-		LightNoPrune            *bool                  `toml:",omitempty"`
-		LightNoSyncServe        *bool                  `toml:",omitempty"`
-		SkipBcVersionCheck      *bool                  `toml:"-"`
-		DatabaseHandles         *int                   `toml:"-"`
-		DatabaseCache           *int
-		DatabaseFreezer         *string
-		TrieCleanCache          *int
-		TrieDirtyCache          *int
-		TrieTimeout             *time.Duration
-		SnapshotCache           *int
-		Preimages               *bool
-		FilterLogCacheSize      *int
-		Miner                   *miner.Config
-		TxPool                  *legacypool.Config
-		BlobPool                *blobpool.Config
-		GPO                     *gasprice.Config
-		EnablePreimageRecording *bool
-		DocRoot                 *string `toml:"-"`
-		RPCGasCap               *uint64
-		RPCEVMTimeout           *time.Duration
-		RPCTxFeeCap             *float64
-		OverrideCancun          *uint64 `toml:",omitempty"`
-		OverrideVerkle          *uint64 `toml:",omitempty"`
-		OverrideOptimismCanyon  *uint64 `toml:",omitempty"`
-		OverrideOptimismEcotone *uint64 `toml:",omitempty"`
-		OverrideOptimismInterop *uint64 `toml:",omitempty"`
-		MPTWitness              *int
-		CircuitParams           *params.CircuitParams
-		KromaZKTrie             *bool
+		Genesis                    *core.Genesis `toml:",omitempty"`
+		NetworkId                  *uint64
+		SyncMode                   *downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  *bool
+		NoPrefetch                 *bool
+		TxLookupLimit              *uint64                `toml:",omitempty"`
+		TransactionHistory         *uint64                `toml:",omitempty"`
+		StateHistory               *uint64                `toml:",omitempty"`
+		StateScheme                *string                `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  *int                   `toml:",omitempty"`
+		LightIngress               *int                   `toml:",omitempty"`
+		LightEgress                *int                   `toml:",omitempty"`
+		LightPeers                 *int                   `toml:",omitempty"`
+		LightNoPrune               *bool                  `toml:",omitempty"`
+		LightNoSyncServe           *bool                  `toml:",omitempty"`
+		SkipBcVersionCheck         *bool                  `toml:"-"`
+		DatabaseHandles            *int                   `toml:"-"`
+		DatabaseCache              *int
+		DatabaseFreezer            *string
+		TrieCleanCache             *int
+		TrieDirtyCache             *int
+		TrieTimeout                *time.Duration
+		SnapshotCache              *int
+		Preimages                  *bool
+		FilterLogCacheSize         *int
+		Miner                      *miner.Config
+		TxPool                     *legacypool.Config
+		BlobPool                   *blobpool.Config
+		GPO                        *gasprice.Config
+		EnablePreimageRecording    *bool
+		DocRoot                    *string `toml:"-"`
+		RPCGasCap                  *uint64
+		RPCEVMTimeout              *time.Duration
+		RPCTxFeeCap                *float64
+		OverrideCancun             *uint64 `toml:",omitempty"`
+		OverrideVerkle             *uint64 `toml:",omitempty"`
+		OverrideOptimismCanyon     *uint64 `toml:",omitempty"`
+		OverrideOptimismEcotone    *uint64 `toml:",omitempty"`
+		OverrideOptimismInterop    *uint64 `toml:",omitempty"`
+		OverrideKromaMPT           *uint64 `toml:",omitempty"`
+		DisableMPTMigration        *bool
+		RollupHistoricalRPC        *string
+		RollupHistoricalRPCTimeout *time.Duration
+		MPTWitness                 *int
+		CircuitParams              *params.CircuitParams
+		KromaZKTrie                *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -291,6 +303,18 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideOptimismInterop != nil {
 		c.OverrideOptimismInterop = dec.OverrideOptimismInterop
+	}
+	if dec.OverrideKromaMPT != nil {
+		c.OverrideKromaMPT = dec.OverrideKromaMPT
+	}
+	if dec.DisableMPTMigration != nil {
+		c.DisableMPTMigration = *dec.DisableMPTMigration
+	}
+	if dec.RollupHistoricalRPC != nil {
+		c.RollupHistoricalRPC = *dec.RollupHistoricalRPC
+	}
+	if dec.RollupHistoricalRPCTimeout != nil {
+		c.RollupHistoricalRPCTimeout = *dec.RollupHistoricalRPCTimeout
 	}
 	if dec.MPTWitness != nil {
 		c.MPTWitness = *dec.MPTWitness

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,12 +23,17 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
+	"net/http"
 	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -41,9 +46,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -51,6 +56,66 @@ var (
 	errBlockNotFound       = errors.New("block not found")
 	errTransactionNotFound = errors.New("transaction not found")
 )
+
+type mockHistoricalBackend struct {
+	mock.Mock
+}
+
+// mockHistoricalBackend does not have a TraceCall, because pre-bedrock there is no debug_traceCall available
+
+func (m *mockHistoricalBackend) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *TraceConfig) ([]*txTraceResult, error) {
+	ret := m.Mock.MethodCalled("TraceBlockByNumber", number, config)
+	return ret[0].([]*txTraceResult), *ret[1].(*error)
+}
+
+func (m *mockHistoricalBackend) ExpectTraceBlockByNumber(number rpc.BlockNumber, config *TraceConfig, out []*txTraceResult, err error) {
+	m.Mock.On("TraceBlockByNumber", number, config).Once().Return(out, &err)
+}
+
+func (m *mockHistoricalBackend) TraceTransaction(ctx context.Context, hash common.Hash, config *TraceConfig) (interface{}, error) {
+	ret := m.Mock.MethodCalled("TraceTransaction", hash, config)
+	return ret[0], *ret[1].(*error)
+}
+
+func (m *mockHistoricalBackend) ExpectTraceTransaction(hash common.Hash, config *TraceConfig, out interface{}, err error) {
+	jsonOut, _ := json.Marshal(out)
+	m.Mock.On("TraceTransaction", hash, config).Once().Return(json.RawMessage(jsonOut), &err)
+}
+
+func newMockHistoricalBackend(t *testing.T, backend *mockHistoricalBackend) string {
+	s := rpc.NewServer()
+	err := node.RegisterApis([]rpc.API{
+		{
+			Namespace:     "debug",
+			Service:       backend,
+			Public:        true,
+			Authenticated: false,
+		},
+	}, nil, s)
+	if err != nil {
+		t.Fatalf("error creating mock historical backend: %v", err)
+	}
+
+	hdlr := node.NewHTTPHandlerStack(s, []string{"*"}, []string{"*"}, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/", hdlr)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("error creating mock historical backend listener: %v", err)
+	}
+
+	go func() {
+		httpS := &http.Server{Handler: mux}
+		httpS.Serve(listener)
+
+		t.Cleanup(func() {
+			httpS.Shutdown(context.Background())
+		})
+	}()
+
+	return fmt.Sprintf("http://%s", listener.Addr().String())
+}
 
 type testBackend struct {
 	chainConfig *params.ChainConfig
@@ -60,15 +125,28 @@ type testBackend struct {
 
 	refHook func() // Hook is invoked when the requested state is referenced
 	relHook func() // Hook is invoked when the requested state is released
+
+	historical     *rpc.Client
+	mockHistorical *mockHistoricalBackend
 }
 
 // testBackend creates a new test backend. OBS: After test is done, teardown must be
 // invoked in order to release associated resources.
 func newTestBackend(t *testing.T, n int, gspec *core.Genesis, generator func(i int, b *core.BlockGen)) *testBackend {
+	mock := new(mockHistoricalBackend)
+	historicalAddr := newMockHistoricalBackend(t, mock)
+
+	historicalClient, err := rpc.Dial(historicalAddr)
+	if err != nil {
+		t.Fatalf("error making historical client: %v", err)
+	}
+
 	backend := &testBackend{
-		chainConfig: gspec.Config,
-		engine:      ethash.NewFaker(),
-		chaindb:     rawdb.NewMemoryDatabase(),
+		chainConfig:    gspec.Config,
+		engine:         ethash.NewFaker(),
+		chaindb:        rawdb.NewMemoryDatabase(),
+		historical:     historicalClient,
+		mockHistorical: mock,
 	}
 	// Generate blocks for testing
 	_, blocks, _ := core.GenerateChainWithGenesis(gspec, backend.engine, n, generator)
@@ -194,6 +272,10 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 		statedb.Finalise(vmenv.ChainConfig().IsEIP158(block.Number()))
 	}
 	return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
+}
+
+func (b *testBackend) HistoricalRPCService() *rpc.Client {
+	return b.historical
 }
 
 func TestTraceCall(t *testing.T) {
@@ -343,19 +425,8 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(big.NewInt(1000)),
 			},
 			config:    nil,
-			expectErr: fmt.Errorf("block #%d %w", genBlocks+1, ethereum.NotFound),
+			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
 			//expect:    nil,
-		},
-		// Kroma: Trace block that doesn't exist anywhere
-		{
-			blockNumber: rpc.BlockNumber(39347856),
-			call: ethapi.TransactionArgs{
-				From:  &accounts[0].addr,
-				To:    &accounts[1].addr,
-				Value: (*hexutil.Big)(big.NewInt(1000)),
-			},
-			config:    nil,
-			expectErr: fmt.Errorf("block #39347856 %w", ethereum.NotFound),
 		},
 		// Standard JSON trace upon the latest block
 		{
@@ -391,7 +462,9 @@ func TestTraceCall(t *testing.T) {
 			},
 			expectErr: nil,
 			// [Scroll: START]
-			expect: ` {"gas":53018,"failed":false,"returnValue":"","accountAfter":null,"structLogs":[{"pc":0,"op":"NUMBER","gas":24946984,"gasCost":2,"depth":1},{"pc":1,"op":"STOP","gas":24946982,"gasCost":0,"depth":1,"stack":["0x1337"]}]}`,
+			expect: ` {"gas":53018,"failed":false,"returnValue":"","accountAfter":null,"structLogs":[
+		{"pc":0,"op":"NUMBER","gas":24946984,"gasCost":2,"depth":1},
+		{"pc":1,"op":"STOP","gas":24946982,"gasCost":0,"depth":1,"stack":["0x1337"]}]}`,
 			// [Scroll: END]
 		},
 	}
@@ -475,6 +548,59 @@ func TestTraceTransaction(t *testing.T) {
 		t.Error("Transaction tracing result is different")
 	}
 }
+func TestTraceTransactionHistorical(t *testing.T) {
+	t.Parallel()
+
+	// Initialize test accounts
+	accounts := newAccounts(2)
+	genesis := &core.Genesis{
+		Config: params.KromaTestConfig,
+		Alloc: core.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	target := common.Hash{}
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
+		// Transfer from account[0] to account[1]
+		//    value: 1000 wei
+		//    fee:   0 wei
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		b.AddTx(tx)
+		target = tx.Hash()
+	})
+	defer backend.mockHistorical.AssertExpectations(t)
+	defer backend.chain.Stop()
+	backend.mockHistorical.ExpectTraceTransaction(
+		target,
+		nil,
+		types.ExecutionResult{
+			Gas:         params.TxGas,
+			Failed:      false,
+			ReturnValue: "",
+			StructLogs:  []*types.StructLogRes{},
+		},
+		nil)
+	api := NewAPI(backend)
+	result, err := api.TraceTransaction(context.Background(), target, nil)
+	if err != nil {
+		t.Errorf("Failed to trace transaction %v", err)
+	}
+	var have *types.ExecutionResult
+	spew.Dump(result)
+	if err := json.Unmarshal(result.(json.RawMessage), &have); err != nil {
+		t.Errorf("failed to unmarshal result %v", err)
+	}
+	if !reflect.DeepEqual(have, &types.ExecutionResult{
+		Gas:         params.TxGas,
+		Failed:      false,
+		ReturnValue: "",
+		StructLogs:  []*types.StructLogRes{},
+	}) {
+		t.Error("Transaction tracing result is different")
+	}
+}
 
 func TestTraceBlock(t *testing.T) {
 	t.Parallel()
@@ -531,7 +657,7 @@ func TestTraceBlock(t *testing.T) {
 		// Trace non-existent block
 		{
 			blockNumber: rpc.BlockNumber(genBlocks + 1),
-			expectErr:   fmt.Errorf("block #%d %w", genBlocks+1, ethereum.NotFound),
+			expectErr:   fmt.Errorf("block #%d not found", genBlocks+1),
 		},
 		// Trace latest block
 		{
@@ -555,7 +681,7 @@ func TestTraceBlock(t *testing.T) {
 				t.Errorf("test %d, want error %v", i, tc.expectErr)
 				continue
 			}
-			if err.Error() != tc.expectErr.Error() {
+			if !reflect.DeepEqual(err, tc.expectErr) {
 				t.Errorf("test %d: error mismatch, want %v, get %v", i, tc.expectErr, err)
 			}
 			continue
@@ -569,6 +695,59 @@ func TestTraceBlock(t *testing.T) {
 		if string(have) != want {
 			t.Errorf("test %d, result mismatch, have\n%v\n, want\n%v\n", i, string(have), want)
 		}
+	}
+}
+
+func TestTraceBlockHistorical(t *testing.T) {
+	t.Parallel()
+
+	// Initialize test accounts
+	accounts := newAccounts(3)
+	genesis := &core.Genesis{
+		Config: params.KromaTestConfig,
+		Alloc: core.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[2].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	genBlocks := 10
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, genBlocks, genesis, func(i int, b *core.BlockGen) {
+		// Transfer from account[0] to account[1]
+		//    value: 1000 wei
+		//    fee:   0 wei
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer backend.mockHistorical.AssertExpectations(t)
+	defer backend.chain.Stop()
+	api := NewAPI(backend)
+
+	var expectErr error
+	var config *TraceConfig
+	blockNumber := rpc.BlockNumber(3)
+	want := `[{"txHash":"0x0000000000000000000000000000000000000000000000000000000000000000","result":{"failed":false,"gas":21000,"returnValue":"","structLogs":[]}}]`
+	var ret []*txTraceResult
+	_ = json.Unmarshal([]byte(want), &ret)
+
+	backend.mockHistorical.ExpectTraceBlockByNumber(blockNumber, config, ret, nil)
+
+	result, err := api.TraceBlockByNumber(context.Background(), blockNumber, config)
+	if expectErr != nil {
+		if err == nil {
+			t.Errorf("want error %v", expectErr)
+		}
+		if !reflect.DeepEqual(err, expectErr) {
+			t.Errorf("error mismatch, want %v, get %v", expectErr, err)
+		}
+	}
+	if err != nil {
+		t.Errorf("want no error, have %v", err)
+	}
+	have, _ := json.Marshal(result)
+	if string(have) != want {
+		t.Errorf("result mismatch, have\n%v\n, want\n%v\n", string(have), want)
 	}
 }
 
@@ -690,7 +869,7 @@ func TestTracingWithOverrides(t *testing.T) {
 				From: &accounts[0].addr,
 				// BLOCKNUMBER PUSH1 MSTORE
 				Input: newRPCBytes(common.Hex2Bytes("4360005260206000f3")),
-				//&hexutil.Bytes{0x43}, // blocknumber
+				// &hexutil.Bytes{0x43}, // blocknumber
 			},
 			config: &TraceCallConfig{
 				BlockOverrides: &ethapi.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(0x1337))},

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
@@ -98,6 +99,13 @@ func (t *prestateTracer) CaptureStart(env *vm.EVM, from common.Address, to commo
 	t.lookupAccount(from)
 	t.lookupAccount(to)
 	t.lookupAccount(env.Context.Coinbase)
+	// [Kroma: START]
+	if env.ChainConfig().Kroma != nil {
+		t.lookupAccount(params.KromaProposerRewardVault)
+		t.lookupAccount(params.KromaProtocolVault)
+		t.lookupAccount(params.KromaValidatorRewardVault)
+	}
+	// [Kroma: END]
 
 	// The recipient balance includes the value transferred.
 	toBal := new(big.Int).Sub(t.pre[to].Balance, value)

--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.sum
+++ b/go.sum
@@ -573,11 +573,16 @@ github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobt
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -29,6 +29,7 @@ import (
 	zktrie "github.com/kroma-network/zktrie/types"
 	"github.com/tyler-smith/go-bip39"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -638,7 +639,6 @@ func (s *BlockChainAPI) BlockNumber() hexutil.Uint64 {
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.
 func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error) {
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -656,7 +656,6 @@ func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, 
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
@@ -697,7 +696,6 @@ func (n *proofList) Delete(key []byte) error {
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -714,7 +712,6 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	var (
 		keys         = make([]common.Hash, len(storageKeys))
 		keyLengths   = make([]int, len(storageKeys))
@@ -941,7 +938,6 @@ func (s *BlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash 
 
 // GetCode returns the code stored at the given address in the state for the given block number.
 func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -959,7 +955,6 @@ func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blo
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
@@ -973,7 +968,6 @@ func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blo
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
 // numbers are also allowed.
 func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, hexKey string, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -991,7 +985,6 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
@@ -1005,7 +998,6 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 	return res[:], state.Error()
 }
 
-/* [kroma unsupported]
 // The HeaderByNumberOrHash method returns a nil error and nil header
 // if the header is not found, but only for nonexistent block numbers. This is
 // different from StateAndHeaderByNumberOrHash. To account for this discrepancy,
@@ -1017,7 +1009,6 @@ func headerByNumberOrHash(ctx context.Context, b Backend, blockNrOrHash rpc.Bloc
 	}
 	return header, err
 }
-*/
 
 // GetBlockReceipts returns the block receipts for the given block hash or number or tag.
 func (s *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]map[string]interface{}, error) {
@@ -1278,7 +1269,6 @@ func (e *revertError) ErrorData() interface{} {
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
 func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
-	/* [kroma unsupported]
 	if blockNrOrHash == nil {
 		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		blockNrOrHash = &latest
@@ -1301,7 +1291,6 @@ func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrO
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	result, err := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, blockOverrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
@@ -1360,7 +1349,6 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 		bNrOrHash = *blockNrOrHash
 	}
 
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, bNrOrHash)
 	if err != nil {
 		return 0, err
@@ -1378,7 +1366,6 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 			return 0, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	return DoEstimateGas(ctx, s.b, args, bNrOrHash, overrides, s.b.RPCGasCap())
 }
 
@@ -1504,9 +1491,7 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
-	/* [kroma unsupported]
 	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
-	*/
 	// deposit-tx post-Canyon only
 	DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
 }
@@ -1540,16 +1525,12 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	switch tx.Type() {
 	case types.DepositTxType:
 		srcHash := tx.SourceHash()
-		/* [kroma unsupported]
 		isSystemTx := tx.IsSystemTx()
-		*/
 		result.SourceHash = &srcHash
-		/* [kroma unsupported]
 		if isSystemTx {
 			// Only include IsSystemTx when true
 			result.IsSystemTx = &isSystemTx
 		}
-		*/
 		result.Mint = (*hexutil.Big)(tx.Mint())
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
@@ -1689,7 +1670,6 @@ func (s *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionAr
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, bNrOrHash)
 	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
@@ -1703,7 +1683,6 @@ func (s *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionAr
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	acl, gasUsed, vmerr, err := AccessList(ctx, s.b, bNrOrHash, args)
 	if err != nil {
 		return nil, err
@@ -1854,7 +1833,6 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 		return (*hexutil.Uint64)(&nonce), nil
 	}
 	// Resolve block number and use its state to ask for the nonce
-	/* [kroma unsupported]
 	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -1872,7 +1850,6 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 			return nil, rpc.ErrNoHistoricalFallback
 		}
 	}
-	*/
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -956,7 +956,7 @@ func TestCall(t *testing.T) {
 				To:    &accounts[1].addr,
 				Value: (*hexutil.Big)(big.NewInt(1000)),
 			},
-			expectErr: errors.New("header not found"),
+			expectErr: ethereum.NotFound,
 		},
 		// transfer on the latest block
 		{

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -86,6 +86,7 @@ type Backend interface {
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine
+	HistoricalRPCService() *rpc.Client
 	Genesis() *types.Block
 
 	// This is copied from filters.Backend

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -405,5 +405,6 @@ func (b *backendMock) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 	return nil
 }
 
-func (b *backendMock) Engine() consensus.Engine { return nil }
-func (b *backendMock) Genesis() *types.Block    { return nil }
+func (b *backendMock) Engine() consensus.Engine          { return nil }
+func (b *backendMock) HistoricalRPCService() *rpc.Client { return nil }
+func (b *backendMock) Genesis() *types.Block             { return nil }

--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -1,0 +1,340 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+var (
+	tracerType = "prestateTracer"
+	// BedrockTransitionBlockExtraData represents the extradata
+	// set in the very first bedrock block. This value must be
+	// less than 32 bytes long or it will create an invalid block.
+	BedrockTransitionBlockExtraData = []byte("BEDROCK")
+)
+
+type ethBackend interface {
+	ChainDb() ethdb.Database
+	BlockChain() *core.BlockChain
+}
+
+type StateMigrator struct {
+	backend       ethBackend
+	db            ethdb.Database
+	zktdb         *trie.Database
+	mptdb         *trie.Database
+	allocPreimage map[common.Hash][]byte
+	tracersAPI    *tracers.API
+	traceCfg      *tracers.TraceConfig
+	migratedRef   *core.MigratedRef
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewStateMigrator(backend ethBackend, tracersAPI *tracers.API) (*StateMigrator, error) {
+	db := backend.ChainDb()
+
+	allocPreimage, err := zkPreimageFromAlloc(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read genesis alloc: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &StateMigrator{
+		backend: backend,
+		db:      db,
+		zktdb: trie.NewDatabase(db, &trie.Config{
+			Preimages:   true,
+			Zktrie:      true,
+			KromaZKTrie: backend.BlockChain().TrieDB().IsKromaZK(),
+		}),
+		mptdb:         trie.NewDatabase(db, &trie.Config{Preimages: true}),
+		allocPreimage: allocPreimage,
+		tracersAPI:    tracersAPI,
+		traceCfg: &tracers.TraceConfig{
+			Tracer:       &tracerType,
+			TracerConfig: json.RawMessage(`{"diffMode": true}`),
+		},
+		migratedRef: core.NewMigratedRef(db),
+
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+func (m *StateMigrator) Start() {
+	log.Info("Start state migrator to migrate ZKT to MPT")
+	go func() {
+		if m.migratedRef.Root() == (common.Hash{}) {
+			var safeHead *types.Header
+			if safe := m.backend.BlockChain().CurrentSafeBlock(); safe != nil {
+				safeHead = safe
+			} else {
+				safeHead = m.backend.BlockChain().Genesis().Header()
+			}
+			log.Info("Start migrate past state")
+			// Start migration from the head block. It takes long time.
+			err := m.migrateAccount(safeHead)
+			if err != nil {
+				log.Error("Failed to migrate state", "error", err)
+				return
+			}
+
+			err = m.ValidateMigratedState(m.migratedRef.Root(), safeHead.Root)
+			if err != nil {
+				log.Error("Migrated state is invalid", "error", err)
+				return
+			}
+			log.Info("Migrated past state have been validated")
+		}
+
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		log.Info("Start a loop to apply state of new block")
+		for {
+			select {
+			case <-ticker.C:
+				currentBlock := m.backend.BlockChain().CurrentSafeBlock()
+				// Skip block that have already been migrated.
+				if currentBlock == nil || m.migratedRef.BlockNumber() >= currentBlock.Number.Uint64() {
+					continue
+				}
+				if m.backend.BlockChain().Config().IsKromaMPT(currentBlock.Time) {
+					return
+				}
+				err := m.applyNewStateTransition(currentBlock.Number.Uint64())
+				if err != nil {
+					log.Error("Failed to apply new state transition", "error", err)
+				}
+			case <-m.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (m *StateMigrator) Stop() {
+	log.Info("Stopping state migrator")
+	m.cancel()
+}
+
+func (m *StateMigrator) migrateAccount(header *types.Header) error {
+	log.Info("Migrate account", "root", header.Root, "number", header.Number)
+	startAt := time.Now()
+	var accounts atomic.Uint64
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	go func() {
+		for ; ; <-ticker.C {
+			select {
+			case <-m.ctx.Done():
+				return
+			default:
+				log.Info("Migrate accounts in progress", "accounts", accounts.Load())
+			}
+		}
+	}()
+
+	mpt, err := trie.NewStateTrie(trie.TrieID(types.EmptyRootHash), m.mptdb)
+	if err != nil {
+		return err
+	}
+
+	zkt, err := trie.NewZkMerkleStateTrie(header.Root, m.zktdb)
+	if err != nil {
+		return err
+	}
+	var mu sync.Mutex
+	err = hashRangeIterator(m.ctx, zkt, NumProcessAccount, func(key, value []byte) error {
+		preimage, err := m.readZkPreimage(key)
+		if err != nil {
+			return err
+		}
+		address := common.BytesToAddress(preimage)
+		log.Debug("Start migrate account", "address", address.Hex())
+		acc, err := types.NewStateAccount(value, true)
+		if err != nil {
+			return err
+		}
+		acc.Root, err = m.migrateStorage(address, acc.Root)
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if err := mpt.UpdateAccount(address, acc); err != nil {
+			return err
+		}
+
+		accounts.Add(1)
+		log.Trace("Account updated in MPT", "account", address.Hex(), "index", common.BytesToHash(key).Hex())
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	root, err := m.commit(mpt, types.EmptyRootHash)
+	if err != nil {
+		return err
+	}
+	log.Info("Account migration finished", "accounts", accounts.Load(), "elapsed", time.Since(startAt))
+
+	if err := m.migratedRef.Update(root, header.Number.Uint64()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *StateMigrator) migrateStorage(
+	address common.Address,
+	zkStorageRoot common.Hash,
+) (common.Hash, error) {
+	startAt := time.Now()
+	log.Debug("Start migrate storage", "address", address.Hex())
+	if zkStorageRoot == (common.Hash{}) {
+		return types.EmptyRootHash, nil
+	}
+
+	id := trie.StorageTrieID(types.EmptyRootHash, crypto.Keccak256Hash(address.Bytes()), types.EmptyRootHash)
+	mpt, err := trie.NewStateTrie(id, m.mptdb)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	zkt, err := trie.NewZkMerkleStateTrie(zkStorageRoot, m.zktdb)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	var mu sync.Mutex
+	var slots atomic.Uint64
+	err = hashRangeIterator(m.ctx, zkt, NumProcessStorage, func(key, value []byte) error {
+		preimage, err := m.readZkPreimage(key)
+		if err != nil {
+			return err
+		}
+		slot := common.BytesToHash(preimage).Bytes()
+		trimmed := common.TrimLeftZeroes(common.BytesToHash(value).Bytes())
+		mu.Lock()
+		defer mu.Unlock()
+		if err := mpt.UpdateStorage(address, slot, trimmed); err != nil {
+			return err
+		}
+
+		slots.Add(1)
+		log.Trace("Updated storage slot to MPT", "contract", address.Hex(), "index", common.BytesToHash(key).Hex())
+		return nil
+	})
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	root, err := m.commit(mpt, types.EmptyRootHash)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	log.Debug("Storage migration finished", "account", address, "slots", slots.Load(), "elapsed", time.Since(startAt))
+	return root, nil
+}
+
+func (m *StateMigrator) readZkPreimage(key []byte) ([]byte, error) {
+	hk := *trie.IteratorKeyToHash(key, true)
+	if preimage, ok := m.allocPreimage[hk]; ok {
+		return preimage, nil
+	}
+	if preimage := m.zktdb.Preimage(hk); preimage != nil {
+		if common.BytesToHash(zk.MustNewSecureHash(preimage).Bytes()).Hex() == hk.Hex() {
+			return preimage, nil
+		}
+	}
+	return []byte{}, fmt.Errorf("preimage does not exist: %s", hk.Hex())
+}
+
+func (m *StateMigrator) commit(mpt *trie.StateTrie, parentHash common.Hash) (common.Hash, error) {
+	root, set, err := mpt.Commit(true)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if set == nil {
+		log.Warn("Tried to commit state changes, but nothing has changed.", "root", root)
+		return root, nil
+	}
+
+	// NOTE(pangssu): It is possible that the keccak256 and poseidon hashes collide, and data loss can occur.
+	for path, mptNode := range set.Nodes {
+		data, _ := m.db.Get(mptNode.Hash.Bytes())
+		if len(data) == 0 {
+			continue
+		}
+		if node, err := zk.NewTreeNodeFromBlob(data); err == nil {
+			return common.Hash{}, fmt.Errorf("hash collision detected: hashKey: %v, path: %v, data: %v, zkNode: %v", mptNode.Hash, path, data, node.Hash())
+		}
+	}
+
+	if err := m.mptdb.Update(root, parentHash, 0, trienode.NewWithNodeSet(set), nil); err != nil {
+		return common.Hash{}, err
+	}
+	if err := m.mptdb.Commit(root, false); err != nil {
+		return common.Hash{}, err
+	}
+	return root, nil
+}
+
+func (m *StateMigrator) FinalizeTransition(transitionBlock types.Block) {
+	cfg := m.backend.BlockChain().Config()
+	// Set the BedrockBlock to transition block number.
+	cfg.BedrockBlock = transitionBlock.Number()
+	// Copy KromaConfig to OptimismConfig.
+	cfg.Optimism = &params.OptimismConfig{
+		EIP1559Denominator:       cfg.Kroma.EIP1559Denominator,
+		EIP1559Elasticity:        cfg.Kroma.EIP1559Elasticity,
+		EIP1559DenominatorCanyon: cfg.Kroma.EIP1559DenominatorCanyon,
+	}
+	// Keep it set to true for genesis validation.
+	cfg.Zktrie = true
+
+	// Write the chain config to disk.
+	genesisHash := rawdb.ReadCanonicalHash(m.db, 0)
+	rawdb.WriteChainConfig(m.db, genesisHash, cfg)
+
+	// Switch trie backend to MPT
+	m.backend.BlockChain().TrieDB().SetBackend(false)
+
+	log.Info("Wrote chain config", "bedrock-block", cfg.BedrockBlock, "zktrie", cfg.Zktrie)
+
+	// TODO(pangssu): Delete this goroutine when other validation logic is implemented.
+	// Perform a final validation of all migrated state. This takes a long time.
+	go func() {
+		startAt := time.Now()
+		log.Info("Start validation for all migrated state")
+		zkBlock := m.backend.BlockChain().GetBlockByNumber(m.migratedRef.BlockNumber())
+		if zkBlock == nil {
+			panic(fmt.Errorf("zk block %d not found", m.migratedRef.BlockNumber()))
+		}
+		if err := m.ValidateMigratedState(m.migratedRef.Root(), zkBlock.Root()); err != nil {
+			panic(err)
+		}
+		log.Info("All migrated state have been validated", "elapsed", time.Since(startAt))
+		m.cancel()
+	}()
+}

--- a/migration/migrator_genesis.go
+++ b/migration/migrator_genesis.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/trie/zk"
+)
+
+func zkPreimageFromAlloc(db ethdb.Database) (map[common.Hash][]byte, error) {
+	genesis, err := core.ReadGenesis(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load genesis from database: %w", err)
+	}
+	preimages := make(map[common.Hash][]byte)
+	for addr, account := range genesis.Alloc {
+		hash := common.BytesToHash(zk.MustNewSecureHash(addr.Bytes()).Bytes())
+		preimages[hash] = addr.Bytes()
+
+		if account.Storage != nil {
+			for key := range account.Storage {
+				hash = common.BytesToHash(zk.MustNewSecureHash(key.Bytes()).Bytes())
+				preimages[hash] = key.Bytes()
+			}
+		}
+	}
+	return preimages, nil
+}

--- a/migration/migrator_newstate.go
+++ b/migration/migrator_newstate.go
@@ -1,0 +1,200 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+type prestateStorage map[string]string
+
+type prestateAccount struct {
+	Balance string          `json:"balance,omitempty"`
+	Nonce   *uint64         `json:"nonce,omitempty"`
+	Code    string          `json:"code,omitempty"`
+	Storage prestateStorage `json:"storage,omitempty"`
+}
+type prestateTracerResult struct {
+	Pre  map[string]prestateAccount `json:"pre"`
+	Post map[string]prestateAccount `json:"post"`
+}
+
+func (m *StateMigrator) updateAccount(stateTrie *trie.StateTrie, stateRoot common.Hash, address common.Address, changes prestateAccount) error {
+	account, _ := stateTrie.GetAccount(address)
+	if account == nil {
+		account = types.NewEmptyStateAccount(false)
+		// CodeHash can only be set for empty state account.
+		if len(changes.Code) != 0 {
+			b := common.Hex2Bytes(strings.TrimPrefix(changes.Code, "0x"))
+			account.CodeHash = crypto.Keccak256Hash(b).Bytes()
+		}
+	}
+
+	if len(changes.Balance) != 0 {
+		balance, ok := new(big.Int).SetString(strings.TrimPrefix(changes.Balance, "0x"), 16)
+		if !ok {
+			return fmt.Errorf("invalid type of balance")
+		}
+		account.Balance = balance
+	}
+	if changes.Nonce != nil {
+		account.Nonce = *changes.Nonce
+	}
+	if len(changes.Storage) != 0 {
+		if bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+			return nil
+		}
+		trieId := trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(address.Bytes()), account.Root)
+		storageTrie, err := trie.NewStateTrie(trieId, m.mptdb)
+		if err != nil {
+			return err
+		}
+		for key, value := range changes.Storage {
+			slot := common.HexToHash(key).Bytes()
+			if len(value) == 0 {
+				if err := storageTrie.DeleteStorage(common.Address{}, slot); err != nil {
+					return err
+				}
+			} else {
+				valueBytes := common.Hex2Bytes(strings.TrimPrefix(value, "0x"))
+				trimmed := common.TrimLeftZeroes(valueBytes)
+				if err := storageTrie.UpdateStorage(common.Address{}, slot, trimmed); err != nil {
+					return err
+				}
+			}
+		}
+		account.Root, err = m.commit(storageTrie, account.Root)
+		if err != nil {
+			return err
+		}
+	}
+
+	return stateTrie.UpdateAccount(address, account)
+}
+
+func (m *StateMigrator) applyEip4788PostState(stateTrie *trie.StateTrie, stateRoot common.Hash, timestamp *big.Int, beaconRoot common.Hash) error {
+	account, _ := stateTrie.GetAccount(params.BeaconRootsStorageAddress)
+	// Skip if the account does not have a contract code.
+	if account == nil || bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+		return nil
+	}
+	// See https://eips.ethereum.org/EIPS/eip-4788
+	bufferLength := new(big.Int).SetUint64(8191)
+	timestampIdx := new(big.Int).Mod(timestamp, bufferLength)
+	rootIdx := new(big.Int).Add(timestampIdx, bufferLength)
+
+	storage := make(prestateStorage)
+	storage[common.BigToHash(timestampIdx).Hex()] = common.BigToHash(timestamp).Hex()
+	storage[common.BigToHash(rootIdx).Hex()] = beaconRoot.Hex()
+	err := m.updateAccount(stateTrie, stateRoot, params.BeaconRootsStorageAddress, prestateAccount{Storage: storage})
+	if err != nil {
+		return fmt.Errorf("failed to apply eip47888 post state: %w", err)
+	}
+	return nil
+}
+
+func (m *StateMigrator) applyNewStateTransition(headNumber uint64) error {
+	start := m.migratedRef.BlockNumber() + 1
+	root := m.migratedRef.Root()
+	for i := start; i <= headNumber; i++ {
+		log.Info("Apply new state to MPT", "block", i, "root", root.TerminalString())
+
+		stateTrie, err := trie.NewStateTrie(trie.StateTrieID(root), m.mptdb)
+		if err != nil {
+			return err
+		}
+
+		// Apply state changes for EIP-4788 process.
+		header := m.backend.BlockChain().GetHeaderByNumber(i)
+		if header == nil {
+			return fmt.Errorf("block %d header not found", i)
+		}
+		if header.ParentBeaconRoot != nil {
+			err = m.applyEip4788PostState(stateTrie, root, new(big.Int).SetUint64(header.Time), *header.ParentBeaconRoot)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Apply state changes for transactions.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		res, err := m.tracersAPI.TraceBlockByNumber(ctx, rpc.BlockNumber(i), m.traceCfg)
+		if err != nil {
+			cancel()
+			return err
+		}
+		cancel()
+		for _, tx := range res {
+			var result prestateTracerResult
+			if err := json.Unmarshal(tx.Result.(json.RawMessage), &result); err != nil {
+				return err
+			}
+			for key, changes := range m.mergeTracerResult(result) {
+				address := common.HexToAddress(key)
+				err := m.updateAccount(stateTrie, root, address, changes)
+				if err != nil {
+					log.Error("Failed to apply new state", "address", address, "err", err)
+				}
+			}
+		}
+
+		root, err = m.commit(stateTrie, root)
+		if err != nil {
+			return err
+		}
+		if err := m.migratedRef.Update(root, header.Number.Uint64()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *StateMigrator) mergeTracerResult(res prestateTracerResult) map[string]prestateAccount {
+	ret := make(map[string]prestateAccount)
+
+	for addr, pre := range res.Pre {
+		post, modified := res.Post[addr]
+		if modified {
+			acc := prestateAccount{
+				Balance: pre.Balance,
+				Nonce:   pre.Nonce,
+				Code:    post.Code,
+				Storage: make(prestateStorage),
+			}
+			if post.Nonce != nil {
+				acc.Nonce = post.Nonce
+			}
+			if len(post.Balance) != 0 {
+				acc.Balance = post.Balance
+			}
+
+			if len(pre.Storage) > 0 || len(post.Storage) > 0 {
+				maps.Copy(acc.Storage, pre.Storage)
+				maps.Copy(acc.Storage, post.Storage)
+				for slot := range acc.Storage {
+					if _, ok := post.Storage[slot]; !ok {
+						acc.Storage[slot] = ""
+					}
+				}
+			}
+
+			ret[addr] = acc
+		}
+	}
+
+	return ret
+}

--- a/migration/migrator_range.go
+++ b/migration/migrator_range.go
@@ -1,0 +1,127 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"runtime"
+
+	"github.com/holiman/uint256"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+var (
+	NumProcessAccount = runtime.NumCPU()
+	NumProcessStorage = runtime.NumCPU()
+)
+
+var hashSpace = new(big.Int).Exp(common.Big2, common.Big256, nil)
+
+// hashRange is a utility to handle ranges of hashes, Split up the
+// hash-space into sections, and 'walk' over the sections
+type hashRange struct {
+	current *uint256.Int
+	step    *uint256.Int
+}
+
+// newHashRange creates a new hashRange, initiated at the start position,
+// and with the step set to fill the desired 'num' chunks
+func newHashRange(start common.Hash, num uint64) *hashRange {
+	left := new(big.Int).Sub(hashSpace, start.Big())
+	step := new(big.Int).Div(
+		new(big.Int).Add(left, new(big.Int).SetUint64(num-1)),
+		new(big.Int).SetUint64(num),
+	)
+	step256 := new(uint256.Int)
+	step256.SetFromBig(step)
+
+	return &hashRange{
+		current: new(uint256.Int).SetBytes32(start[:]),
+		step:    step256,
+	}
+}
+
+// Next pushes the hash range to the next interval.
+func (r *hashRange) Next() bool {
+	if r.step.IsZero() {
+		return false
+	}
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
+		return false
+	}
+	r.current = next
+	return true
+}
+
+// Start returns the first hash in the current interval.
+func (r *hashRange) Start() common.Hash {
+	return r.current.Bytes32()
+}
+
+// End returns the last hash in the current interval.
+func (r *hashRange) End() common.Hash {
+	// If the end overflows (non divisible range), return a shorter interval
+	next, overflow := new(uint256.Int).AddOverflow(r.current, r.step)
+	if overflow {
+		return common.MaxHash
+	}
+	return next.SubUint64(next, 1).Bytes32()
+}
+
+// hashRangeIterator divides the iteration range using trie node hashes and traverses leaf nodes.
+// The traversed nodes are returned via the onLeaf callback function.
+func hashRangeIterator(ctx context.Context, tr state.Trie, num int, onLeaf func(key, value []byte) error) error {
+	r := newHashRange(common.Hash{}, uint64(num))
+
+	eg, cCtx := errgroup.WithContext(ctx)
+	for {
+		startKey := r.Start().Bytes()
+		endKey := r.End().Bytes()
+		eg.Go(func() error {
+			nodeIt, err := tr.NodeIterator(startKey)
+			if err != nil {
+				return fmt.Errorf("failed to open node iterator (root: %s): %w", tr.Hash(), err)
+			}
+			iter := trie.NewIterator(nodeIt)
+			for iter.Next() {
+				if bytes.Compare(iter.Key, startKey) == -1 {
+					continue
+				}
+				if bytes.Compare(iter.Key, endKey) == 1 {
+					break
+				}
+				err = onLeaf(iter.Key, iter.Value)
+				if err != nil {
+					return err
+				}
+				if bytes.Equal(iter.Key, endKey) {
+					break
+				}
+			}
+			if iter.Err != nil {
+				return fmt.Errorf("failed to traverse state trie (root: %s): %w", tr.Hash(), iter.Err)
+			}
+			return nil
+		})
+
+		if !r.Next() {
+			break
+		}
+
+		select {
+		case <-cCtx.Done():
+			return cCtx.Err()
+		default:
+		}
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/migration/migrator_validate.go
+++ b/migration/migrator_validate.go
@@ -1,0 +1,138 @@
+package migration
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+func (m *StateMigrator) ValidateMigratedState(mptRoot common.Hash, zkRoot common.Hash) error {
+	var accounts atomic.Uint64
+	var slots atomic.Uint64
+
+	eg, cCtx := errgroup.WithContext(m.ctx)
+	eg.Go(func() error {
+		mpt, err := trie.NewStateTrie(trie.StateTrieID(mptRoot), m.mptdb)
+		if err != nil {
+			log.Error("Failed to create state trie", "root", mptRoot, "err", err)
+			return err
+		}
+
+		zkt, err := trie.NewZkMerkleStateTrie(zkRoot, m.zktdb)
+		if err != nil {
+			log.Error("Failed to create zk state trie", "root", zkRoot, "err", err)
+			return err
+		}
+
+		var mu sync.Mutex
+		err = hashRangeIterator(cCtx, zkt, NumProcessAccount, func(key, value []byte) error {
+			zktAcc, err := types.NewStateAccount(value, true)
+			if err != nil {
+				log.Error("Invalid account encountered during traversal", "err", err)
+				return err
+			}
+
+			preimage, err := m.readZkPreimage(key)
+			if err != nil {
+				return err
+			}
+			addr := common.BytesToAddress(preimage)
+			mu.Lock()
+			mptAcc, err := mpt.GetAccount(addr)
+			mu.Unlock()
+			if err != nil || mptAcc == nil {
+				log.Error("Failed to get account in MPT", "address", addr, "err", err)
+				return err
+			}
+			if mptAcc.Balance.Cmp(zktAcc.Balance) != 0 {
+				return fmt.Errorf("account %s balance mismatch. expected %s, got %s", addr, zktAcc.Balance, mptAcc.Balance)
+			}
+			if mptAcc.Nonce != zktAcc.Nonce {
+				return fmt.Errorf("account %s nonce mismatch. expected %d, got %d", addr, zktAcc.Nonce, mptAcc.Nonce)
+			}
+			if !bytes.Equal(mptAcc.CodeHash, zktAcc.CodeHash) {
+				return fmt.Errorf("account %s codehash mismatch. expected %s, got %s", addr, common.BytesToHash(zktAcc.CodeHash), common.BytesToHash(mptAcc.CodeHash))
+			}
+
+			if zktAcc.Root != (common.Hash{}) {
+				id := trie.StorageTrieID(mptRoot, crypto.Keccak256Hash(addr.Bytes()), mptAcc.Root)
+				mptStorage, err := trie.NewStateTrie(id, m.mptdb)
+				if err != nil {
+					log.Error("Failed to create state trie", "root", mptAcc.Root, "err", err)
+					return err
+				}
+
+				zktStorage, err := trie.NewZkMerkleStateTrie(zktAcc.Root, m.zktdb)
+				if err != nil {
+					log.Error("Failed to create zk state trie", "root", zktAcc.Root, "err", err)
+					return err
+				}
+				var mu sync.Mutex
+				err = hashRangeIterator(cCtx, zktStorage, NumProcessStorage, func(key, value []byte) error {
+					preimage, err := m.readZkPreimage(key)
+					if err != nil {
+						return err
+					}
+					slot := common.BytesToHash(preimage).Bytes()
+					zktVal := common.TrimLeftZeroes(common.BytesToHash(value).Bytes())
+					mu.Lock()
+					mptVal, err := mptStorage.GetStorage(addr, slot)
+					mu.Unlock()
+					if err != nil {
+						log.Error("Failed to get storage value in MPT", "err", err)
+						return err
+					}
+					if !bytes.Equal(mptVal, zktVal) {
+						return fmt.Errorf("account %s storage (slot: %s) mismatch. expected %s, got %s", addr, common.BytesToHash(slot), common.BytesToHash(zktVal), common.BytesToHash(mptVal))
+					}
+
+					slots.Add(1)
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+			} else if mptAcc.Root != types.EmptyRootHash {
+				return fmt.Errorf("account %s root should be empty root hash. got %s", addr, mptAcc.Root)
+			}
+
+			accounts.Add(1)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// In progress logger
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	go func() {
+		for ; ; <-ticker.C {
+			select {
+			case <-m.ctx.Done():
+				return
+			default:
+				log.Info("Migrated state validation in progress", "accounts", accounts.Load(), "slots", slots.Load())
+			}
+		}
+	}()
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -18,6 +18,7 @@
 package miner
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -41,6 +43,10 @@ import (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
+}
+
+type BackendWithHistoricalState interface {
+	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error)
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -295,6 +295,13 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		gasLimit:    args.GasLimit,
 	}
 
+	// [Kroma: ZKT to MPT]
+	// Migration block do not include user transactions that are in the mempool in the block.
+	if w.chainConfig.IsKromaMPTActivationBlock(args.Timestamp) {
+		fullParams.noTxs = true
+	}
+	// [Kroma: END]
+
 	// Since we skip building the empty block when using the tx pool, we need to explicitly
 	// validate the BuildPayloadArgs here.
 	blockTime, err := w.validateParams(fullParams)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -17,6 +17,7 @@
 package miner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -34,8 +35,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/migration"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -737,20 +740,35 @@ func (w *worker) resultLoop() {
 
 // makeEnv creates a new environment for the sealing block.
 func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase common.Address) (*environment, error) {
-	// Retrieve the parent state to execute on top and start a prefetcher for
-	// the miner to speed block sealing up a bit.
-	state, err := w.chain.StateAt(parent.Root)
-	/* [kroma unsupported]
-	if err != nil && w.chainConfig.Optimism != nil { // Allow the miner to reorg its own chain arbitrarily deep
-		if historicalBackend, ok := w.eth.(BackendWithHistoricalState); ok {
-			var release tracers.StateReleaseFunc
-			parentBlock := w.eth.BlockChain().GetBlockByHash(parent.Hash())
-			state, release, err = historicalBackend.StateAtBlock(context.Background(), parentBlock, ^uint64(0), nil, false, false)
-			state = state.Copy()
-			release()
+	var state *state.StateDB
+	var err error
+
+	// [Kroma: ZKT to MPT]
+	if w.chainConfig.IsKromaMPTActivationBlock(header.Time) {
+		w.chainConfig.Zktrie = false
+		w.chain.TrieDB().SetBackend(false)
+		migratedRef := w.chain.GetMigratedRef()
+		if migratedRef.BlockNumber() > 0 && migratedRef.BlockNumber() == header.Number.Uint64()-1 {
+			state, err = w.chain.StateAt(migratedRef.Root())
+		} else {
+			err = errors.New("migration has not been completed")
+		}
+	} else {
+		// Retrieve the parent state to execute on top and start a prefetcher for
+		// the miner to speed block sealing up a bit.
+		state, err = w.chain.StateAt(parent.Root)
+		if err != nil && w.chainConfig.Optimism != nil { // Allow the miner to reorg its own chain arbitrarily deep
+			if historicalBackend, ok := w.eth.(BackendWithHistoricalState); ok {
+				var release tracers.StateReleaseFunc
+				parentBlock := w.eth.BlockChain().GetBlockByHash(parent.Hash())
+				state, release, err = historicalBackend.StateAtBlock(context.Background(), parentBlock, ^uint64(0), nil, false, false)
+				state = state.Copy()
+				release()
+			}
 		}
 	}
-	*/
+	// [Kroma: END]
+
 	if err != nil {
 		return nil, err
 	}
@@ -1078,6 +1096,10 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		context := core.NewEVMBlockContext(header, w.chain, nil, w.chainConfig, env.state)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, env.state, w.chainConfig, vm.Config{})
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv, env.state)
+	}
+
+	if w.chainConfig.IsKromaMPTActivationBlock(header.Time) {
+		header.Extra = migration.BedrockTransitionBlockExtraData
 	}
 	return env, nil
 }

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -8,26 +8,31 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
 type KromaChainConfig struct {
-	CanyonTime  *uint64
-	EcotoneTime *uint64
+	CanyonTime   *uint64
+	EcotoneTime  *uint64
+	KromaMPTTime *uint64
 }
 
 var KromaChainConfigs = map[uint64]*KromaChainConfig{
 	KromaMainnetChainID: {
-		CanyonTime:  uint64ptr(1708502400),
-		EcotoneTime: uint64ptr(1714032001),
+		CanyonTime:   uint64ptr(1708502400),
+		EcotoneTime:  uint64ptr(1714032001),
+		KromaMPTTime: nil,
 	},
 	KromaSepoliaChainID: {
-		CanyonTime:  uint64ptr(1707897600),
-		EcotoneTime: uint64ptr(1713340800),
+		CanyonTime:   uint64ptr(1707897600),
+		EcotoneTime:  uint64ptr(1713340800),
+		KromaMPTTime: nil,
 	},
 	KromaDevnetChainID: {
-		CanyonTime:  uint64ptr(1707292800),
-		EcotoneTime: uint64ptr(1712908800),
+		CanyonTime:   uint64ptr(1707292800),
+		EcotoneTime:  uint64ptr(1712908800),
+		KromaMPTTime: nil,
 	},
 }
 
@@ -88,6 +93,7 @@ func LoadKromaChainConfig(chainID uint64) (*ChainConfig, error) {
 		RegolithTime:                  &genesisActivation,
 		CanyonTime:                    kromaChainConfig.CanyonTime,
 		EcotoneTime:                   kromaChainConfig.EcotoneTime,
+		KromaMPTTime:                  kromaChainConfig.KromaMPTTime,
 		TerminalTotalDifficulty:       common.Big0,
 		TerminalTotalDifficultyPassed: true,
 		Ethash:                        nil,

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -73,6 +73,16 @@ const (
 	errMsgBatchTooLarge    = "batch too large"
 )
 
+var ErrNoHistoricalFallback = NoHistoricalFallbackError{}
+
+type NoHistoricalFallbackError struct{}
+
+func (e NoHistoricalFallbackError) ErrorCode() int { return -32801 }
+
+func (e NoHistoricalFallbackError) Error() string {
+	return "no historical RPC is available for this historical (pre-bedrock) execution request"
+}
+
 type methodNotFoundError struct{ method string }
 
 func (e *methodNotFoundError) ErrorCode() int { return -32601 }

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -946,17 +946,14 @@ func newMerkleTreeIterator(
 	}
 	if it.err == nil && rootNode != nil {
 		it.stack = []merkleTreeIteratorNode{rootNode}
-		it.seek(start)
+		if len(start) != 0 {
+			it.seek(zk.NewTreePathFromHashBig(common.BytesToHash(start)))
+		}
 	}
 	return it
 }
 
-func (it *merkleTreeIterator) seek(path []byte) {
-	if len(path) == 0 {
-		return
-	}
-	path = zk.NewTreePathFromHashBig(common.BytesToHash(path))
-
+func (it *merkleTreeIterator) seek(path zk.TreePath) {
 	for _, p := range path {
 		if parent, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorParentNode); ok {
 			if child := it.resolveNode(parent.children[p]); child != nil {
@@ -967,51 +964,125 @@ func (it *merkleTreeIterator) seek(path []byte) {
 			if it.err != nil {
 				return
 			}
-		} else {
-			break
+		}
+		break
+	}
+
+	if _, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorParentNode); ok {
+		it.nextLeaf()
+	}
+
+	if leaf, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorLeafNode); ok {
+		switch bytes.Compare(path, zk.NewTreePathFromHashBig(common.BytesToHash(leaf.key))) {
+		case -1: // path < leaf path
+		loop1:
+			for it.prevLeaf() {
+				switch bytes.Compare(path, zk.NewTreePathFromHashBig(common.BytesToHash(it.lastNodeAsLeaf().key))) {
+				case -1: // path < leaf path
+					continue
+				case 0: // path == leaf path
+					break loop1
+				case 1:
+					it.nextLeaf()
+					break loop1
+				}
+			}
+		case 0: // leaf path == path
+		case 1: // leaf path < path
+		loop2:
+			for it.nextLeaf() {
+				switch bytes.Compare(path, zk.NewTreePathFromHashBig(common.BytesToHash(it.lastNodeAsLeaf().key))) {
+				case -1: // path < leaf path
+					it.prevLeaf()
+					break loop2
+				case 0: // path == leaf path
+					break loop2
+				case 1:
+					continue
+				}
+			}
+			return
 		}
 	}
 
 	if len(it.path) == 0 {
-		return // root node is not parent node
+		return
 	}
-
 	// When using the Next function, it always moves to the next node.
 	// Therefore, it sets the previous node of the node retrieved by seek to the last visited node.
 	lastIdx := len(it.path) - 1
 	if it.path[lastIdx] == right {
 		it.path[lastIdx] = left
 		it.stack[len(it.stack)-1] = it.resolveNode(it.parentOfLastNode().children[left])
-		for {
-			if parent, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorParentNode); ok {
-				for _, path := range []byte{right, left} {
-					if child := it.resolveNode(parent.children[path]); child != nil {
-						it.stack = append(it.stack, child)
-						it.path = append(it.path, path)
-						break
-					}
-					if it.err != nil {
-						return
-					}
-				}
-			} else {
-				break
-			}
-		}
+		it.visitBeforeLeafNode()
 	} else {
 		it.path = it.path[:lastIdx]
 		it.stack = it.stack[:len(it.stack)-1]
 	}
 }
 
+func (it *merkleTreeIterator) visitBeforeLeafNode() {
+	for {
+		if parent, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorParentNode); ok {
+			for _, path := range []byte{right, left} {
+				if child := it.resolveNode(parent.children[path]); child != nil {
+					it.stack = append(it.stack, child)
+					it.path = append(it.path, path)
+					break
+				}
+				if it.err != nil {
+					return
+				}
+			}
+		} else {
+			break
+		}
+	}
+}
+
+func (it *merkleTreeIterator) prevLeaf() bool {
+	if _, ok := it.stack[len(it.stack)-1].(*merkleTreeIteratorLeafNode); ok {
+		for len(it.path) != 0 { // Infinite loop if there are still paths left to visit
+			switch lastPathIndex := len(it.path) - 1; it.path[lastPathIndex] {
+			case left: // left visited. go up
+				it.path = it.path[:len(it.path)-1]
+				it.stack = it.stack[:len(it.stack)-1]
+			case right: // right visited. go left
+				if leftNode := it.resolveNode(it.parentOfLastNode().children[left]); leftNode != nil {
+					it.path[lastPathIndex] = left
+					it.stack[len(it.stack)-1] = leftNode
+					it.visitBeforeLeafNode()
+					return true
+				}
+				if it.err != nil {
+					return false
+				}
+				// left does not exist. go up
+				it.path = it.path[:len(it.path)-1]
+				it.stack = it.stack[:len(it.stack)-1]
+			}
+		}
+	}
+	return false
+}
+
+func (it *merkleTreeIterator) nextLeaf() bool {
+	for it.Next(true) {
+		if it.Leaf() {
+			return true
+		}
+	}
+	if len(it.stack) == 1 && len(it.path) == 0 {
+		it.stack = nil
+	}
+	return false
+}
+
 func (it *merkleTreeIterator) Next(bool) bool {
 	if it.err != nil {
 		return false
 	}
-	if len(it.stack) == 0 {
-		return false
-	}
-	if it.stack == nil { // end of iterator traversal
+	if len(it.stack) == 0 { // end of iterator traversal
 		return false
 	}
 	if it.path == nil { // first visit. Starting from the root

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -18,20 +18,25 @@ package trie
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"fmt"
+	"math/big"
 	"math/rand"
+	"strings"
 	"testing"
 
 	zkt "github.com/kroma-network/zktrie/types"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/zk"
-	"golang.org/x/exp/slices"
 )
 
 func TestEmptyIterator(t *testing.T) {
@@ -745,4 +750,212 @@ func TestMerkleTreeIterator(t *testing.T) {
 			t.Errorf("iterated leaf count invalid. expected %d, but got %d", len(testdata1), leafCount)
 		}
 	})
+
+	t.Run("single", func(t *testing.T) {
+		prepareTest := func() (*ZkTrie, *memorydb.Database, kvs) {
+			db := memorydb.New()
+			zkdb := NewZkDatabase(rawdb.NewDatabase(db))
+			trie, _ := NewZkTrie(common.Hash{}, zkdb)
+			input := testdata1[0]
+			trie.TryUpdate(common.LeftPadBytes([]byte(input.k), 32), []byte(input.v))
+
+			root, _, _ := trie.Commit(false)
+			zkdb.Commit(root, true)
+			return trie, db, input
+		}
+
+		t.Run("no start", func(t *testing.T) {
+			trie, db, _ := prepareTest()
+			it := trie.MustNodeIterator(nil)
+			count, leafCount := testIterator(t, db, it)
+			if count != 1 {
+				t.Errorf("iterated node count invalid. expected %d, but got %d", 1, count)
+			}
+			if leafCount != 1 {
+				t.Errorf("iterated leaf count invalid. expected %d, but got %d", 1, leafCount)
+			}
+		})
+
+		t.Run("start < leaf", func(t *testing.T) {
+			trie, db, _ := prepareTest()
+			it := trie.MustNodeIterator(common.BigToHash(common.Big2).Bytes())
+			count, leafCount := testIterator(t, db, it)
+			if count != 1 {
+				t.Errorf("iterated node count invalid. expected %d, but got %d", 1, count)
+			}
+			if leafCount != 1 {
+				t.Errorf("iterated leaf count invalid. expected %d, but got %d", 1, leafCount)
+			}
+		})
+
+		t.Run("start == leaf", func(t *testing.T) {
+			trie, db, input := prepareTest()
+			treePath := zk.NewTreePathFromZkHash(*zk.MustNewSecureHash(common.LeftPadBytes([]byte(input.k), 32)))
+			it := trie.MustNodeIterator(common.BigToHash(treePath.ToBigInt()).Bytes())
+			count, leafCount := testIterator(t, db, it)
+			if count != 1 {
+				t.Errorf("iterated node count invalid. expected %d, but got %d", 1, count)
+			}
+			if leafCount != 1 {
+				t.Errorf("iterated leaf count invalid. expected %d, but got %d", 1, leafCount)
+			}
+		})
+
+		t.Run("leaf < start", func(t *testing.T) {
+			trie, db, _ := prepareTest()
+			it := trie.MustNodeIterator(new(big.Int).Sub(math.BigPow(2, 256), big.NewInt(20)).Bytes())
+			count, leafCount := testIterator(t, db, it)
+			if count != 0 {
+				t.Errorf("iterated node count invalid. expected %d, but got %d", 0, count)
+			}
+			if leafCount != 0 {
+				t.Errorf("iterated leaf count invalid. expected %d, but got %d", 0, leafCount)
+			}
+		})
+	})
+
+	t.Run("start param", func(t *testing.T) {
+		db := memorydb.New()
+		zdb := NewZkDatabase(rawdb.NewDatabase(db))
+		tree := NewEmptyZkMerkleStateTrie(zdb)
+		tree.MustUpdate(common.BigToHash(new(big.Int).SetInt64(10)).Bytes(), []byte("a"))
+		tree.MustUpdate(common.BigToHash(new(big.Int).SetInt64(45)).Bytes(), []byte("b"))
+
+		root, _, _ := tree.Commit(false)
+		zdb.Commit(root, true)
+
+		it := tree.MustNodeIterator(new(big.Int).Sub(math.BigPow(2, 256), big.NewInt(20)).Bytes())
+		count, leafCount := testIterator(t, db, it)
+		if count != 0 {
+			t.Errorf("iterated node count invalid. expected %d, but got %d", 0, count)
+		}
+		if leafCount != 0 {
+			t.Errorf("iterated leaf count invalid. expected %d, but got %d", 0, leafCount)
+		}
+	})
+
+	// 2117868253024658673051308919765768251327889971706193468262358283651495249312
+	// 5890867801457181665214479254972498000781191528432013068122435103377766174560
+	// 14581765644332007355603742199734881084194908881797547524839575783062290731888
+	// 34788104062452934851384508780622905500996384124020206338343429550016154937976
+	// 35276556762053997527613056591322528636494104613584587955086221921567012068952
+	// 35360899632278431044740218782056701006787372914479814587499001065171395100648
+	// 37464597366772015210317945055100241299952644205502865319476387775685341350804
+	// 37969619727885826713456741609104273363135728311753922979242122609203067018480
+	// 49105898062310628859001440408801641574777586797109612022294302697255598990260
+	// 52741712599410822789960629764379820729046689701270413750704650756582052966208
+	// 60605793585936038718222944469367330975045253165943558504994436015126663057264
+	// 85820665183479862833099943033748518022104258034302536812924589654960629631092
+	// 85903213226554376758871722034242209534889372863809613891381864212832081120192
+	// 90325294576998166929651976356705470786861187287245759150875554730994004964376
+	// 100426110323909178507910617048938140138509083918485403644527157931210594668280
+	// 101121973535399381299596552991112472380608726703043018240306005545403524541156
+	// 107728238818287576212658976290069527420728087670830176810004760597624147961456
+	// 108965031955345082684882074272074576895157534795165059799486221336737027828244
+	// 109990652738555876101121666461374586270194093281384129526042736168378582559940
+	// 110211460199408811616376306299384222697381109719033443765762911326375974320200
+	t.Run("startKey", func(t *testing.T) {
+		testLeafCount := func(expectedLeafCount int) func(t *testing.T) {
+			return func(t *testing.T) {
+				db := memorydb.New()
+				zdb := NewZkDatabase(rawdb.NewDatabase(db))
+				tree := NewEmptyZkMerkleStateTrie(zdb)
+
+				keys, values := makeTreeInput()
+				for i := range keys {
+					tree.MustUpdate(keys[i], values[i])
+				}
+				root, _, _ := tree.Commit(false)
+				if err := zdb.Commit(root, true); err != nil {
+					t.Error(err)
+				}
+
+				var startKey []byte
+				if names := strings.Split(t.Name(), "/"); names[len(names)-1] != "null" {
+					start, _ := new(big.Int).SetString(names[len(names)-1], 10)
+					startKey = common.BigToHash(start).Bytes()
+				}
+				//tree, _ := NewZkMerkleStateTrie(root, zdb)
+				//it := tree.MustNodeIterator(startKey)
+				it := tree.MustNodeIterator(startKey)
+				if it.Error() != nil {
+					t.Error(it.Error())
+				}
+				_, leafCount := testIterator(t, db, it)
+				if leafCount != expectedLeafCount {
+					t.Errorf("expected leaf count : %v, but got : %v", expectedLeafCount, leafCount)
+				}
+			}
+		}
+
+		testRangeRandom := func(expectedLeafCount int) func(t *testing.T) {
+			return func(t *testing.T) {
+				names := strings.Split(t.Name(), "/")
+				startRandomRange := strings.Split(names[len(names)-1], "~")
+				for i := 0; i < 100; i++ {
+					start := randomBigInt(
+						startRandomRange[0],
+						startRandomRange[1],
+					)
+					t.Run(start.String(), testLeafCount(expectedLeafCount))
+				}
+			}
+		}
+
+		t.Run("null", testLeafCount(20))
+		t.Run("0~2117868253024658673051308919765768251327889971706193468262358283651495249312", testRangeRandom(20))
+		t.Run("2117868253024658673051308919765768251327889971706193468262358283651495249311", testLeafCount(20))
+		t.Run("2117868253024658673051308919765768251327889971706193468262358283651495249312", testLeafCount(20)) // leaf hit
+		t.Run("2117868253024658673051308919765768251327889971706193468262358283651495249313", testLeafCount(19))
+		t.Run("2117868253024658673051308919765768251327889971706193468262358283651495249313~5890867801457181665214479254972498000781191528432013068122435103377766174559", testRangeRandom(19))
+		t.Run("5890867801457181665214479254972498000781191528432013068122435103377766174559", testLeafCount(19))
+		t.Run("5890867801457181665214479254972498000781191528432013068122435103377766174560", testLeafCount(19)) // leaf hit
+		t.Run("5890867801457181665214479254972498000781191528432013068122435103377766174561", testLeafCount(18))
+		t.Run("14581765644332007355603742199734881084194908881797547524839575783062290731888", testLeafCount(18)) // leaf hit
+		t.Run("34788104062452934851384508780622905500996384124020206338343429550016154937976", testLeafCount(17)) // leaf hit
+		t.Run("35276556762053997527613056591322528636494104613584587955086221921567012068952", testLeafCount(16)) // leaf hit
+		t.Run("35360899632278431044740218782056701006787372914479814587499001065171395100648", testLeafCount(15)) // leaf hit
+		t.Run("37464597366772015210317945055100241299952644205502865319476387775685341350804", testLeafCount(14)) // leaf hit
+		t.Run("37969619727885826713456741609104273363135728311753922979242122609203067018480", testLeafCount(13)) // leaf hit
+		t.Run("37969619727885826713456741609104273363135728311753922979242122609203067018481~49105898062310628859001440408801641574777586797109612022294302697255598990259", testRangeRandom(12))
+		t.Run("43059581450286369774720893806032160531653066764655610223233743297647867892559", testLeafCount(12))
+		t.Run("49105898062310628859001440408801641574777586797109612022294302697255598990260", testLeafCount(12)) // leaf hit
+		t.Run("52741712599410822789960629764379820729046689701270413750704650756582052966208", testLeafCount(11)) // leaf hit
+		t.Run("60605793585936038718222944469367330975045253165943558504994436015126663057264", testLeafCount(10)) // leaf hit
+		t.Run("85820665183479862833099943033748518022104258034302536812924589654960629631092", testLeafCount(9))  // leaf hit
+		t.Run("85903213226554376758871722034242209534889372863809613891381864212832081120192", testLeafCount(8))  // leaf hit
+		t.Run("90325294576998166929651976356705470786861187287245759150875554730994004964376", testLeafCount(7))  // leaf hit
+		t.Run("90325294576998166929651976356705470786861187287245759150875554730994004964377~100426110323909178507910617048938140138509083918485403644527157931210594668279", testRangeRandom(6))
+		t.Run("94522316217657177309342980577705593912865267091010285900227687201142635166164", testLeafCount(6))
+		t.Run("100426110323909178507910617048938140138509083918485403644527157931210594668280", testLeafCount(6)) // leaf hit
+		t.Run("101121973535399381299596552991112472380608726703043018240306005545403524541156", testLeafCount(5)) // leaf hit
+		t.Run("107728238818287576212658976290069527420728087670830176810004760597624147961456", testLeafCount(4)) // leaf hit
+		t.Run("108965031955345082684882074272074576895157534795165059799486221336737027828244", testLeafCount(3)) // leaf hit
+		t.Run("109990652738555876101121666461374586270194093281384129526042736168378582559940", testLeafCount(2)) // leaf hit
+		t.Run("110211460199408811616376306299384222697381109719033443765762911326375974320200", testLeafCount(1)) // leaf hit
+		t.Run("110211460199408811616376306299384222697381109719033443765762911326375974320201", testLeafCount(0))
+		t.Run("110211460199408811616376306299384222697381109719033443765762911326375974320201~115792089237316195423570985008687907853269984665640564039457584007913129639935", testRangeRandom(0))
+		t.Run("115792089237316195423570985008687907853269984665640564039457584007913129639935", testLeafCount(0)) // 2^256-1
+	})
+}
+
+func makeTreeInput() ([][]byte, [][]byte) {
+	r := rand.New(rand.NewSource(0))
+	keys := make([][]byte, 20)
+	values := make([][]byte, 20)
+	for i := range keys {
+		keys[i] = make([]byte, 32)
+		values[i] = make([]byte, 32)
+		r.Read(keys[i])
+		r.Read(values[i])
+	}
+	return keys, values
+}
+
+func randomBigInt(start, end string) *big.Int {
+	startNum, _ := new(big.Int).SetString(start, 10)
+	endNum, _ := new(big.Int).SetString(end, 10)
+	rangeNum := new(big.Int).Sub(endNum, startNum)
+	randomNum, _ := crand.Int(crand.Reader, rangeNum)
+	return new(big.Int).Add(startNum, randomNum)
 }


### PR DESCRIPTION
Migrate the backend of state trie from ZK Trie to MPT for better performance and user experience, and to enable zkVM fault proof.
This PR also involves reducing code and state differences with [op-geth](https://github.com/ethereum-optimism/op-geth).
- Revive the `IsSystemTx()` function.
- Revive the RollupHistoricalRPC flag.
- Re-enable SELFDESTRUCT after transition to MPT.

This PR should be merged after #118 is merged.