### PR TITLE
feat: new state migration approach

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1877,6 +1877,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			wstart = time.Now()
 			status WriteStatus
 		)
+		// [Kroma: START]
+		if bc.chainConfig.KromaMPTTime != nil && *bc.chainConfig.KromaMPTTime > block.Time() {
+			statedb.OnCommitForMigration = WriteStateChanges
+		}
+		// [Kroma: END]
 		if !setHead {
 			// [Scroll: START]
 			// EvmTraces & StorageTrace being nil is safe because l2geth's p2p server is stoped and the code will not execute there.

--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -101,6 +101,16 @@ func SerializeStateChanges[T map[common.Address]bool | map[common.Hash][]byte | 
 	return buf.Bytes(), nil
 }
 
+func DeserializeStateChanges[T map[common.Address]bool | map[common.Hash][]byte | map[common.Hash]map[common.Hash][]byte](data []byte) (T, error) {
+	var result T
+	buf := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buf)
+	if err := decoder.Decode(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func ReadStateChanges(db ethdb.KeyValueStore, blockNumber uint64) (map[common.Address]bool, map[common.Hash][]byte, map[common.Hash]map[common.Hash][]byte, error) {
 	enc, err := db.Get(DestructChangesKey(blockNumber))
 	if err != nil {
@@ -127,16 +137,6 @@ func ReadStateChanges(db ethdb.KeyValueStore, blockNumber uint64) (map[common.Ad
 		return nil, nil, nil, err
 	}
 	return destruct, accounts, storages, nil
-}
-
-func DeserializeStateChanges[T map[common.Address]bool | map[common.Hash][]byte | map[common.Hash]map[common.Hash][]byte](data []byte) (T, error) {
-	var result T
-	buf := bytes.NewBuffer(data)
-	decoder := gob.NewDecoder(buf)
-	if err := decoder.Decode(&result); err != nil {
-		return nil, err
-	}
-	return result, nil
 }
 
 // WriteStateChanges should be called in Kroma MPT migration time

--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -1,13 +1,18 @@
 package core
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var ErrHaltOnStateTransition = errors.New("since migration is disabled, transitioning to MPT is not possible")
@@ -20,12 +25,20 @@ type MigratedRef struct {
 	number uint64
 }
 
+var (
+	accountChangesPrefix  = []byte("aC-")
+	storageChangesPrefix  = []byte("sC-")
+	destructChangesPrefix = []byte("dC-")
+	migratedRootKey       = []byte("MigratedRoot")
+	migratedNumberKey     = []byte("MigratedNumber")
+)
+
 func NewMigratedRef(db ethdb.Database) *MigratedRef {
 	ref := &MigratedRef{db: db}
-	if b, _ := db.Get([]byte("migration-root")); len(b) > 0 {
+	if b, _ := db.Get(migratedRootKey); len(b) > 0 {
 		ref.root = common.BytesToHash(b)
 	}
-	if b, _ := db.Get([]byte("migration-number")); len(b) > 0 {
+	if b, _ := db.Get(migratedNumberKey); len(b) > 0 {
 		ref.number = hexutil.MustDecodeUint64(string(b))
 	}
 	return ref
@@ -34,10 +47,14 @@ func NewMigratedRef(db ethdb.Database) *MigratedRef {
 func (mr *MigratedRef) Update(root common.Hash, number uint64) error {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
-	if err := mr.db.Put([]byte("migration-root"), root.Bytes()); err != nil {
+
+	mr.root = root
+	mr.number = number
+
+	if err := mr.db.Put(migratedRootKey, root.Bytes()); err != nil {
 		return fmt.Errorf("failed to update migrated state root: %w", err)
 	}
-	if err := mr.db.Put([]byte("migration-number"), []byte(hexutil.EncodeUint64(number))); err != nil {
+	if err := mr.db.Put(migratedNumberKey, []byte(hexutil.EncodeUint64(number))); err != nil {
 		return fmt.Errorf("failed to update migrated block number: %w", err)
 	}
 	mr.root = root
@@ -55,4 +72,128 @@ func (mr *MigratedRef) BlockNumber() uint64 {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	return mr.number
+}
+
+// encodeBlockNumber encodes a block number as big endian uint64
+func encodeBlockNumber(number uint64) []byte {
+	enc := make([]byte, 8)
+	binary.BigEndian.PutUint64(enc, number)
+	return enc
+}
+
+func AccountChangesKey(blockNumber uint64) []byte {
+	return append(accountChangesPrefix, encodeBlockNumber(blockNumber)...)
+}
+
+func StorageChangesKey(blockNumber uint64) []byte {
+	return append(storageChangesPrefix, encodeBlockNumber(blockNumber)...)
+}
+
+func DestructChangesKey(blockNumber uint64) []byte {
+	return append(destructChangesPrefix, encodeBlockNumber(blockNumber)...)
+}
+
+func ReadStateChanges(db ethdb.KeyValueStore, blockNumber uint64) (map[common.Address]bool, map[common.Hash][]byte, map[common.Hash]map[common.Hash][]byte, error) {
+	enc, err := db.Get(DestructChangesKey(blockNumber))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	destruct, err := DeserializeStateChanges[map[common.Address]bool](enc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	enc, err = db.Get(AccountChangesKey(blockNumber))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	accounts, err := DeserializeStateChanges[map[common.Hash][]byte](enc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	enc, err = db.Get(StorageChangesKey(blockNumber))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	storages, err := DeserializeStateChanges[map[common.Hash]map[common.Hash][]byte](enc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return destruct, accounts, storages, nil
+}
+
+// Note: it's should be called in MigrationTime
+func WriteStateChanges(db ethdb.KeyValueStore, blockNumber uint64, stateObjectsDestruct map[common.Address]*types.StateAccount, accounts map[common.Hash][]byte, storages map[common.Hash]map[common.Hash][]byte) error {
+	batch := db.NewBatch()
+	stateObjectsDestructInfo := make(map[common.Address]bool)
+
+	// TODO: Do we need to check if batch.ValueSize() > ethdb.IdealBatchSize, have storages size limit?
+	for addr := range stateObjectsDestruct {
+		if addr.Cmp(params.SystemAddress) == 0 {
+			continue
+		}
+		stateObjectsDestructInfo[addr] = true
+	}
+
+	serializedDestruct, err := SerializeStateChanges(stateObjectsDestructInfo)
+	if err != nil {
+		return err
+	}
+	err = batch.Put(DestructChangesKey(blockNumber), serializedDestruct)
+	if err != nil {
+		return err
+	}
+
+	serializedAccounts, err := SerializeStateChanges(accounts)
+	if err != nil {
+		return err
+	}
+	err = batch.Put(AccountChangesKey(blockNumber), serializedAccounts)
+	if err != nil {
+		return err
+	}
+	serializedStorages, err := SerializeStateChanges(storages)
+	if err != nil {
+		return err
+	}
+	err = batch.Put(StorageChangesKey(blockNumber), serializedStorages)
+	if err != nil {
+		return err
+	}
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func SerializeStateChanges[T map[common.Address]bool | map[common.Hash][]byte | map[common.Hash]map[common.Hash][]byte](data T) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	encoder := gob.NewEncoder(buf)
+	if err := encoder.Encode(data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DeleteStateChanges(db ethdb.KeyValueStore, blockNumber uint64) error {
+	batch := db.NewBatch()
+	if err := batch.Delete(DestructChangesKey(blockNumber)); err != nil {
+		return err
+	}
+	if err := batch.Delete(AccountChangesKey(blockNumber)); err != nil {
+		return err
+	}
+	if err := batch.Delete(StorageChangesKey(blockNumber)); err != nil {
+		return err
+	}
+	return batch.Write()
+}
+
+func DeserializeStateChanges[T map[common.Address]bool | map[common.Hash][]byte | map[common.Hash]map[common.Hash][]byte](data []byte) (T, error) {
+	var result T
+	buf := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buf)
+	if err := decoder.Decode(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -158,8 +158,11 @@ type StateDB struct {
 	StorageDeleted int
 
 	// Testing hooks
-	onCommit             func(states *triestate.Set) // Hook invoked when commit is performed
+	onCommit func(states *triestate.Set) // Hook invoked when commit is performed
+
+	// [Kroma: ZKT to MPT]
 	OnCommitForMigration func(s ethdb.KeyValueStore, blockNumber uint64, stateObjectsDestruct map[common.Address]*types.StateAccount, accounts map[common.Hash][]byte, storages map[common.Hash]map[common.Hash][]byte) error
+	// [Kroma: END]
 }
 
 // New creates a new state from a given trie.
@@ -1430,13 +1433,14 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 		if s.onCommit != nil {
 			s.onCommit(set)
 		}
-
+		// [Kroma: ZKT to MPT]
 		if s.OnCommitForMigration != nil {
 			err := s.OnCommitForMigration(s.db.DiskDB(), block, s.stateObjectsDestruct, s.accounts, s.storages)
 			if err != nil {
 				return common.Hash{}, err
 			}
 		}
+		// [Kroma: END]
 	}
 	// Clear all internal flags at the end of commit operation.
 	s.accounts = make(map[common.Hash][]byte)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -45,7 +45,6 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
@@ -360,7 +359,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if eth.blockchain.Config().Zktrie && eth.blockchain.Config().KromaMPTTime != nil && !config.DisableMPTMigration {
 		head := eth.BlockChain().CurrentBlock()
 		if !eth.blockchain.Config().IsKromaMPT(head.Time) {
-			migrator, err := migration.NewStateMigrator(eth, tracers.NewAPI(eth.APIBackend))
+			migrator, err := migration.NewStateMigrator(eth)
 			if err != nil {
 				log.Error("Fail to start state migrator", "error", err)
 			} else {

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
@@ -99,13 +98,6 @@ func (t *prestateTracer) CaptureStart(env *vm.EVM, from common.Address, to commo
 	t.lookupAccount(from)
 	t.lookupAccount(to)
 	t.lookupAccount(env.Context.Coinbase)
-	// [Kroma: START]
-	if env.ChainConfig().Kroma != nil {
-		t.lookupAccount(params.KromaProposerRewardVault)
-		t.lookupAccount(params.KromaProtocolVault)
-		t.lookupAccount(params.KromaValidatorRewardVault)
-	}
-	// [Kroma: END]
 
 	// The recipient balance includes the value transferred.
 	toBal := new(big.Int).Sub(t.pre[to].Balance, value)

--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -13,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -22,13 +20,10 @@ import (
 	"github.com/ethereum/go-ethereum/trie/zk"
 )
 
-var (
-	tracerType = "prestateTracer"
-	// BedrockTransitionBlockExtraData represents the extradata
-	// set in the very first bedrock block. This value must be
-	// less than 32 bytes long or it will create an invalid block.
-	BedrockTransitionBlockExtraData = []byte("BEDROCK")
-)
+// BedrockTransitionBlockExtraData represents the extradata
+// set in the very first bedrock block. This value must be
+// less than 32 bytes long or it will create an invalid block.
+var BedrockTransitionBlockExtraData = []byte("BEDROCK")
 
 type ethBackend interface {
 	ChainDb() ethdb.Database
@@ -41,15 +36,13 @@ type StateMigrator struct {
 	zktdb         *trie.Database
 	mptdb         *trie.Database
 	allocPreimage map[common.Hash][]byte
-	tracersAPI    *tracers.API
-	traceCfg      *tracers.TraceConfig
 	migratedRef   *core.MigratedRef
 
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-func NewStateMigrator(backend ethBackend, tracersAPI *tracers.API) (*StateMigrator, error) {
+func NewStateMigrator(backend ethBackend) (*StateMigrator, error) {
 	db := backend.ChainDb()
 
 	allocPreimage, err := zkPreimageFromAlloc(db)
@@ -68,12 +61,7 @@ func NewStateMigrator(backend ethBackend, tracersAPI *tracers.API) (*StateMigrat
 		}),
 		mptdb:         trie.NewDatabase(db, &trie.Config{Preimages: true}),
 		allocPreimage: allocPreimage,
-		tracersAPI:    tracersAPI,
-		traceCfg: &tracers.TraceConfig{
-			Tracer:       &tracerType,
-			TracerConfig: json.RawMessage(`{"diffMode": true}`),
-		},
-		migratedRef: core.NewMigratedRef(db),
+		migratedRef:   core.NewMigratedRef(db),
 
 		ctx:    ctx,
 		cancel: cancel,

--- a/migration/migrator_newstate.go
+++ b/migration/migrator_newstate.go
@@ -1,115 +1,125 @@
 package migration
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"maps"
-	"math/big"
-	"strings"
-	"time"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-type prestateStorage map[string]string
-
-type prestateAccount struct {
-	Balance string          `json:"balance,omitempty"`
-	Nonce   *uint64         `json:"nonce,omitempty"`
-	Code    string          `json:"code,omitempty"`
-	Storage prestateStorage `json:"storage,omitempty"`
-	Deleted bool            `json:"deleted,omitempty"`
-}
-
-type prestateTracerResult struct {
-	Pre  map[string]prestateAccount `json:"pre"`
-	Post map[string]prestateAccount `json:"post"`
-}
-
-func (m *StateMigrator) updateAccount(stateTrie *trie.StateTrie, stateRoot common.Hash, address common.Address, changes prestateAccount) error {
-	account, _ := stateTrie.GetAccount(address)
-	if account == nil {
-		account = types.NewEmptyStateAccount(false)
-		// CodeHash can only be set for empty state account.
-		if len(changes.Code) != 0 {
-			b := common.Hex2Bytes(strings.TrimPrefix(changes.Code, "0x"))
-			account.CodeHash = crypto.Keccak256Hash(b).Bytes()
-		}
-	}
-
-	if changes.Deleted {
-		account = types.NewEmptyStateAccount(false)
-	}
-
-	if len(changes.Balance) != 0 {
-		balance, ok := new(big.Int).SetString(strings.TrimPrefix(changes.Balance, "0x"), 16)
-		if !ok {
-			return fmt.Errorf("invalid type of balance")
-		}
-		account.Balance = balance
-	}
-	if changes.Nonce != nil {
-		account.Nonce = *changes.Nonce
-	}
-	if len(changes.Storage) != 0 {
-		if bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
-			return nil
-		}
-		trieId := trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(address.Bytes()), account.Root)
-		storageTrie, err := trie.NewStateTrie(trieId, m.mptdb)
-		if err != nil {
-			return err
-		}
-		for key, value := range changes.Storage {
-			slot := common.HexToHash(key).Bytes()
-			if len(value) == 0 {
-				if err := storageTrie.DeleteStorage(common.Address{}, slot); err != nil {
-					return err
-				}
-			} else {
-				valueBytes := common.Hex2Bytes(strings.TrimPrefix(value, "0x"))
-				trimmed := common.TrimLeftZeroes(valueBytes)
-				if err := storageTrie.UpdateStorage(common.Address{}, slot, trimmed); err != nil {
-					return err
-				}
-			}
-		}
-		account.Root, err = m.commit(storageTrie, account.Root)
-		if err != nil {
-			return err
-		}
-	}
-
-	return stateTrie.UpdateAccount(address, account)
-}
-
-func (m *StateMigrator) applyEip4788PostState(stateTrie *trie.StateTrie, stateRoot common.Hash, timestamp *big.Int, beaconRoot common.Hash) error {
-	account, _ := stateTrie.GetAccount(params.BeaconRootsStorageAddress)
-	// Skip if the account does not have a contract code.
-	if account == nil || bytes.Equal(account.CodeHash, types.EmptyCodeHash.Bytes()) {
+// remove all storage values in the input storage trie
+func deleteAccountStorage(mptStorageTrie *trie.StateTrie) error {
+	if mptStorageTrie.Hash().Cmp(types.EmptyRootHash) == 0 {
 		return nil
 	}
-	// See https://eips.ethereum.org/EIPS/eip-4788
-	bufferLength := new(big.Int).SetUint64(8191)
-	timestampIdx := new(big.Int).Mod(timestamp, bufferLength)
-	rootIdx := new(big.Int).Add(timestampIdx, bufferLength)
 
-	storage := make(prestateStorage)
-	storage[common.BigToHash(timestampIdx).Hex()] = common.BigToHash(timestamp).Hex()
-	storage[common.BigToHash(rootIdx).Hex()] = beaconRoot.Hex()
-	err := m.updateAccount(stateTrie, stateRoot, params.BeaconRootsStorageAddress, prestateAccount{Storage: storage})
+	storageIt, err := mptStorageTrie.NodeIterator(nil)
 	if err != nil {
-		return fmt.Errorf("failed to apply eip47888 post state: %w", err)
+		return err
+	}
+	storageIter := trie.NewIterator(storageIt)
+	for storageIter.Next() {
+		if err := mptStorageTrie.DeleteStorage(common.Address{}, storageIter.Key); err != nil {
+			return err
+		}
+	}
+
+	if storageIter.Err != nil {
+		return storageIter.Err
+	}
+
+	return nil
+}
+
+func (m *StateMigrator) applyDestructChanges(mptStateTrie *trie.StateTrie, root common.Hash, destructChanges map[common.Address]bool) error {
+	for addr := range destructChanges {
+		acc, err := mptStateTrie.GetAccount(addr)
+		if err != nil {
+			return err
+		}
+		if acc == nil {
+			continue
+		}
+
+		if err := mptStateTrie.DeleteAccount(addr); err != nil {
+			return err
+		}
+
+		id := trie.StorageTrieID(root, crypto.Keccak256Hash(addr.Bytes()), acc.Root)
+		mptStorageTrie, err := trie.NewStateTrie(id, m.mptdb)
+		if err != nil {
+			return err
+		}
+
+		if err := deleteAccountStorage(mptStorageTrie); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func (m *StateMigrator) applyAccountChanges(mptStateTrie *trie.StateTrie, root common.Hash, accountChanges map[common.Hash][]byte, storageChanges map[common.Hash]map[common.Hash][]byte) error {
+	for hk, val := range accountChanges {
+		preimage, err := m.readZkPreimage(hk)
+		if err != nil {
+			return err
+		}
+		addr := common.BytesToAddress(preimage)
+		acc, err := types.NewStateAccount(val, true)
+		if err != nil {
+			return err
+		}
+		acc.Root = types.EmptyRootHash
+
+		mptAcc, err := mptStateTrie.GetAccount(addr)
+		if err != nil {
+			return err
+		}
+		if mptAcc != nil {
+			acc.Root = mptAcc.Root
+		}
+
+		if changes, ok := storageChanges[hk]; ok {
+			id := trie.StorageTrieID(root, crypto.Keccak256Hash(addr.Bytes()), acc.Root)
+			mptStorageTrie, err := trie.NewStateTrie(id, m.mptdb)
+			if err != nil {
+				return err
+			}
+			acc.Root, err = m.applyStorageChanges(mptStorageTrie, acc.Root, changes)
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := mptStateTrie.UpdateAccount(addr, acc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *StateMigrator) applyStorageChanges(mptStorageTrie *trie.StateTrie, storageRoot common.Hash, changes map[common.Hash][]byte) (common.Hash, error) {
+	for hk, val := range changes {
+		preimage, err := m.readZkPreimage(hk)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		slotKey := common.BytesToHash(preimage).Bytes()
+		if (common.BytesToHash(val) == common.Hash{}) {
+			if err := mptStorageTrie.DeleteStorage(common.Address{}, slotKey); err != nil {
+				return common.Hash{}, err
+			}
+		} else {
+			trimmed := common.TrimLeftZeroes(common.BytesToHash(val).Bytes())
+			if err := mptStorageTrie.UpdateStorage(common.Address{}, slotKey, trimmed); err != nil {
+				return common.Hash{}, err
+			}
+		}
+	}
+
+	return m.commit(mptStorageTrie, storageRoot)
 }
 
 func (m *StateMigrator) applyNewStateTransition(headNumber uint64) error {
@@ -118,105 +128,34 @@ func (m *StateMigrator) applyNewStateTransition(headNumber uint64) error {
 	for i := start; i <= headNumber; i++ {
 		log.Info("Apply new state to MPT", "block", i, "root", root.TerminalString())
 
-		stateTrie, err := trie.NewStateTrie(trie.StateTrieID(root), m.mptdb)
+		mptStateTrie, err := trie.NewStateTrie(trie.StateTrieID(root), m.mptdb)
 		if err != nil {
 			return err
 		}
 
-		// Apply state changes for EIP-4788 process.
-		header := m.backend.BlockChain().GetHeaderByNumber(i)
-		if header == nil {
-			return fmt.Errorf("block %d header not found", i)
-		}
-		if header.ParentBeaconRoot != nil {
-			err = m.applyEip4788PostState(stateTrie, root, new(big.Int).SetUint64(header.Time), *header.ParentBeaconRoot)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Apply state changes for transactions.
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		res, err := m.tracersAPI.TraceBlockByNumber(ctx, rpc.BlockNumber(i), m.traceCfg)
-		if err != nil {
-			cancel()
-			return err
-		}
-		cancel()
-		for _, tx := range res {
-			var result prestateTracerResult
-			if err := json.Unmarshal(tx.Result.(json.RawMessage), &result); err != nil {
-				return err
-			}
-			for key, changes := range m.mergeTracerResult(result) {
-				address := common.HexToAddress(key)
-				err := m.updateAccount(stateTrie, root, address, changes)
-				if err != nil {
-					log.Error("Failed to apply new state", "address", address, "err", err)
-				}
-			}
-		}
-
-		root, err = m.commit(stateTrie, root)
+		destructChanges, accountChanges, storageChanges, err := core.ReadStateChanges(m.db, i)
 		if err != nil {
 			return err
 		}
-		if err := m.migratedRef.Update(root, header.Number.Uint64()); err != nil {
+		if err := m.applyDestructChanges(mptStateTrie, root, destructChanges); err != nil {
+			return err
+		}
+		if err := m.applyAccountChanges(mptStateTrie, root, accountChanges, storageChanges); err != nil {
+			return err
+		}
+
+		root, err = m.commit(mptStateTrie, root)
+		if err != nil {
+			return err
+		}
+		if err := m.migratedRef.Update(root, i); err != nil {
+			return err
+		}
+
+		if err := core.DeleteStateChanges(m.db, i); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func (m *StateMigrator) mergeTracerResult(res prestateTracerResult) map[string]prestateAccount {
-	ret := make(map[string]prestateAccount)
-
-	for addr, pre := range res.Pre {
-		acc := prestateAccount{
-			Balance: pre.Balance,
-			Nonce:   pre.Nonce,
-			Code:    pre.Code,
-			Storage: pre.Storage,
-		}
-		if _, ok := res.Post[addr]; !ok {
-			acc.Deleted = true
-		}
-		ret[addr] = acc
-	}
-
-	for addr, post := range res.Post {
-		if acc, modified := ret[addr]; modified {
-			if len(post.Balance) > 0 && acc.Balance != post.Balance {
-				acc.Balance = post.Balance
-			}
-			if post.Nonce != nil && acc.Nonce != post.Nonce {
-				acc.Nonce = post.Nonce
-			}
-			if len(post.Code) > 0 && acc.Code != post.Code {
-				acc.Code = post.Code
-			}
-			storage := make(prestateStorage)
-			maps.Copy(storage, acc.Storage)
-			maps.Copy(storage, post.Storage)
-			if len(storage) > 0 {
-				for k := range storage {
-					if _, ok := post.Storage[k]; !ok {
-						storage[k] = ""
-					}
-				}
-				acc.Storage = storage
-			}
-			ret[addr] = acc
-		} else {
-			ret[addr] = prestateAccount{
-				Balance: post.Balance,
-				Nonce:   post.Nonce,
-				Code:    post.Code,
-				Storage: post.Storage,
-			}
-		}
-	}
-
-	return ret
 }

--- a/migration/migrator_newstate.go
+++ b/migration/migrator_newstate.go
@@ -155,6 +155,8 @@ func (m *StateMigrator) applyNewStateTransition(headNumber uint64) error {
 		if err := core.DeleteStateChanges(m.db, i); err != nil {
 			return err
 		}
+
+		prevRoot = root
 	}
 
 	return nil

--- a/migration/migrator_validate.go
+++ b/migration/migrator_validate.go
@@ -42,7 +42,8 @@ func (m *StateMigrator) ValidateMigratedState(mptRoot common.Hash, zkRoot common
 				return err
 			}
 
-			preimage, err := m.readZkPreimage(key)
+			hk := trie.IteratorKeyToHash(key, true)
+			preimage, err := m.readZkPreimage(*hk)
 			if err != nil {
 				return err
 			}
@@ -79,7 +80,8 @@ func (m *StateMigrator) ValidateMigratedState(mptRoot common.Hash, zkRoot common
 				}
 				var mu sync.Mutex
 				err = hashRangeIterator(cCtx, zktStorage, NumProcessStorage, func(key, value []byte) error {
-					preimage, err := m.readZkPreimage(key)
+					hk := trie.IteratorKeyToHash(key, true)
+					preimage, err := m.readZkPreimage(*hk)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
## Description
This PR introduces a new approach to state migration by changing the mechanism used in `applyNewTransition`. Instead of relying on the Trace API to obtain the `stateDiff`, the process now utilizes data from `stateDB.Commit()`. This ensures more robust handling of state changes, not only those triggered by user-executed transactions, but also those occurring due to other factors outside the scope captured by the Trace API. For example, this includes cases such as EIP-4788 sys calls and failed deposit transactions in Geth, which may not be fully captured by the Trace API. As a result, the new approach effectively addresses these edge cases and improves overall system stability.


### Main Logic
1. During `stateDB.Commit()`, `stateDiff` are recorded in a temporary space within rawdb on a per-block basis. The recorded data includes:
    - `stateObjectsDestruct`: Storage or account data marked for deletion.
    - `accounts`: Account data that needs to be updated.
    - `storages`: Storage data that needs to be updated.
3. The `migrator` retrieves the `stateDiff` stored in rawdb based on the `SafeBlock` and uses it to update the MPT.