### PR TITLE
feat: change predeploy contract addresses

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -543,15 +543,19 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 	}
 
-	// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
-	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
 	// [Kroma: START]
+	l1FeeVault := params.OptimismL1FeeRecipient
+	if st.evm.ChainConfig().IsPreKromaMPT(st.evm.Context.Time) {
+		l1FeeVault = params.KromaProposerRewardVault
+	}
+	// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
+	// Note kromaConfig will not be nil if rules.IsOptimismBedrock is true
 	if kromaConfig := st.evm.ChainConfig().Kroma; kromaConfig != nil && rules.IsOptimismBedrock && !st.msg.IsDepositTx {
 		if st.evm.ChainConfig().IsKromaMPT(st.evm.Context.Time) {
-			st.state.AddBalance(params.KromaProtocolVault, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
+			st.state.AddBalance(params.OptimismBaseFeeRecipient, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
 		}
 		if cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); cost != nil {
-			st.state.AddBalance(params.KromaProposerRewardVault, cost)
+			st.state.AddBalance(l1FeeVault, cost)
 		}
 	}
 	// [Kroma: END]

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -547,7 +547,9 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
 	// [Kroma: START]
 	if kromaConfig := st.evm.ChainConfig().Kroma; kromaConfig != nil && rules.IsOptimismBedrock && !st.msg.IsDepositTx {
-		st.state.AddBalance(params.KromaProtocolVault, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
+		if st.evm.ChainConfig().IsKromaMPT(st.evm.Context.Time) {
+			st.state.AddBalance(params.KromaProtocolVault, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
+		}
 		if cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); cost != nil {
 			st.state.AddBalance(params.KromaProposerRewardVault, cost)
 		}

--- a/core/types/fee_distribution.go
+++ b/core/types/fee_distribution.go
@@ -45,7 +45,7 @@ func NewFeeDistributionFunc(config *params.ChainConfig, statedb StateGetter) Fee
 		}
 
 		if blockNum != cacheBlockNum {
-			scalar = statedb.GetState(L1BlockAddr, ValidatorRewardScalarSlot).Big().Uint64()
+			scalar = statedb.GetState(KromaL1BlockAddr, ValidatorRewardScalarSlot).Big().Uint64()
 			if scalar > 10000 {
 				scalar = 0
 			}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -23,12 +23,19 @@ import (
 )
 
 var (
+	// The base fee portion of the transaction fee accumulates at this predeploy
+	OptimismBaseFeeRecipient = common.HexToAddress("0x4200000000000000000000000000000000000019")
+	// The L1 portion of the transaction fee accumulates at this predeploy
+	OptimismL1FeeRecipient = common.HexToAddress("0x420000000000000000000000000000000000001A")
+
+	// [Kroma: START]
 	// The protocol fee portion of the transaction fee accumulates at this predeploy
 	KromaProtocolVault = common.HexToAddress("0x4200000000000000000000000000000000000006")
 	// The L1 portion of the transaction fee accumulates at this predeploy
 	KromaProposerRewardVault = common.HexToAddress("0x4200000000000000000000000000000000000007")
 	// The validator reward portion of the transaction fee accumulates at this predeploy
 	KromaValidatorRewardVault = common.HexToAddress("0x4200000000000000000000000000000000000008")
+	// [Kroma: END]
 )
 
 const (


### PR DESCRIPTION
This PR is to change L1Block and fee recipient addresses at MPT migration fork.

You can test this by spinning up a Kroma devnet as follows:
1. Checkout to [this branch](https://github.com/kroma-network/kroma/pull/393) at `kroma`.
2. Replace the docker image for L2 with `smstack15/geth:mpt-a61dbd0ba`(temp image for testing) at `docker-compose.yml`.
3. Set MPT migration time offset as `"l2GenesisKromaMPTTimeOffset": "0x4"` and spin up the devnet.

Note that the l1 fee will not be accrued in this devnet, since `L1Block` address is not yet changed so that the fee scalars are recognized as 0. The l1 fee part is tested locally and checked that l1 fee is normally accrued if L1Block address is not changed after mpt migration.