### PR TITLE
fix: revise `eth_getProof` error by setting Zktrie to false

### DIFF
--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -307,6 +307,7 @@ func (m *StateMigrator) FinalizeTransition(transitionBlock types.Block) {
 	rawdb.WriteChainConfig(m.db, genesisHash, cfg)
 
 	// Switch trie backend to MPT
+	cfg.Zktrie = false
 	m.backend.BlockChain().TrieDB().SetBackend(false)
 
 	log.Info("Wrote chain config", "bedrock-block", cfg.BedrockBlock, "zktrie", cfg.Zktrie)


### PR DESCRIPTION
There was a bug that the result of `eth_getProof` is not verified after MPT migration, and it turns out that the the hashing function when generating account proof at `eth_getProof` depended on `Zktrie` config, which was set to be `true` at `finalizeTransition`.

This PR fixes by adding a single line to make the option to be false after writing config to rawdb at `finalizeTransition`.