### PR TITLE
fix: add check for data length of L1Block transaction after MPT migration

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -244,7 +244,9 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (l
 		// edge case: for the very first Ecotone block we still need to use the Bedrock
 		// function. We detect this edge case by seeing if the function selector is the old one
 		if len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {
-			l1BaseFee, costFunc, err = extractL1GasParamsEcotone(data)
+			// [Kroma: START]
+			l1BaseFee, costFunc, err = extractL1GasParamsEcotone(data, config.IsKromaMPT(time))
+			// [Kroma: END]
 			return
 		}
 	}
@@ -266,10 +268,15 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (l
 
 // extractEcotoneL1GasParams extracts the gas parameters necessary to compute gas from L1 attribute
 // info calldata after the Ecotone upgrade, but not for the very first Ecotone block.
-func extractL1GasParamsEcotone(data []byte) (l1BaseFee *big.Int, costFunc l1CostFunc, err error) {
-	if len(data) != 196 {
+func extractL1GasParamsEcotone(data []byte, isKromaMPT bool) (l1BaseFee *big.Int, costFunc l1CostFunc, err error) {
+	// [Kroma: START]
+	if len(data) != 196 && !isKromaMPT {
 		return nil, nil, fmt.Errorf("expected 196 L1 info bytes, got %d", len(data))
+	} else if len(data) != 164 && isKromaMPT {
+		return nil, nil, fmt.Errorf("expected 164 L1 info bytes, got %d", len(data))
 	}
+	// [Kroma: END]
+
 	// data layout assumed for Ecotone:
 	// offset type varname
 	// 0      <selector>

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -270,6 +270,8 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (l
 // info calldata after the Ecotone upgrade, but not for the very first Ecotone block.
 func extractL1GasParamsEcotone(data []byte, isKromaMPT bool) (l1BaseFee *big.Int, costFunc l1CostFunc, err error) {
 	// [Kroma: START]
+	// Since validatorRewardScalar is removed after the Kroma MPT upgrade, the calldata can be 164 bytes long.
+	// Validate the length of the L1 info bytes accordingly.
 	if len(data) != 196 && !isKromaMPT {
 		return nil, nil, fmt.Errorf("expected 196 L1 info bytes, got %d", len(data))
 	} else if len(data) != 164 && isKromaMPT {
@@ -289,7 +291,6 @@ func extractL1GasParamsEcotone(data []byte, isKromaMPT bool) (l1BaseFee *big.Int
 	// 68    uint256 _blobBaseFee,
 	// 100   bytes32 _hash,
 	// 132   bytes32 _batcherHash,
-	// 164   uint256 _validatorRewardScalar
 	l1BaseFee = new(big.Int).SetBytes(data[36:68])
 	l1BlobBaseFee := new(big.Int).SetBytes(data[68:100])
 	l1BaseFeeScalar := new(big.Int).SetBytes(data[4:8])

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -105,7 +105,7 @@ func TestExtractEcotoneGasParams(t *testing.T) {
 
 	// make sure wrong amont of data results in error
 	data = append(data, 0x00) // tack on garbage byte
-	_, _, err = extractL1GasParamsEcotone(data)
+	_, _, err = extractL1GasParamsEcotone(data, false)
 	require.Error(t, err)
 }
 

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -93,7 +93,7 @@ func TestExtractEcotoneGasParams(t *testing.T) {
 	}
 	require.True(t, config.IsOptimismEcotone(0))
 
-	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar, false)
+	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar)
 
 	_, costFunc, _, err := extractL1GasParams(config, 0, data)
 	require.NoError(t, err)
@@ -112,16 +112,18 @@ func TestExtractEcotoneGasParams(t *testing.T) {
 // [Kroma: START]
 func TestExtractKromaMPTGasParams(t *testing.T) {
 	zeroTime := uint64(0)
-	// create a config where ecotone upgrade is active
+	// create a config where Kroma MPT upgrade is active
 	config := &params.ChainConfig{
 		Kroma:        params.KromaTestConfig.Kroma,
 		RegolithTime: &zeroTime,
 		EcotoneTime:  &zeroTime,
 		KromaMPTTime: &zeroTime,
 	}
-	require.True(t, config.IsOptimismEcotone(0))
+	require.True(t, config.IsKromaMPT(0))
 
-	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar, true)
+	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar)
+	// Remove last 32 bytes (validatorRewardScalar).
+	data = data[:len(data)-32]
 
 	_, costFunc, _, err := extractL1GasParams(config, 0, data)
 	require.NoError(t, err)
@@ -175,7 +177,7 @@ func getBedrockL1Attributes(baseFee, overhead, scalar *big.Int) []byte {
 	return data
 }
 
-func getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar *big.Int, isKromaMPT bool) []byte {
+func getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar *big.Int) []byte {
 	ignored := big.NewInt(1234)
 	data := []byte{}
 	uint256 := make([]byte, 32)
@@ -192,9 +194,7 @@ func getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScal
 	data = append(data, ignored.FillBytes(uint256)...)
 	data = append(data, ignored.FillBytes(uint256)...)
 	// [Kroma: START]
-	if !isKromaMPT {
-		data = append(data, ignored.FillBytes(uint256)...)
-	}
+	data = append(data, ignored.FillBytes(uint256)...)
 	// [Kroma: END]
 	return data
 }


### PR DESCRIPTION
Found an issue while testing at devnet, and this PR is fixing that issue.

While deriving receipt from block data, it uses `extractL1GasParamsEcotone` function, and it checks the length of calldata of L1Block transaction to be 196. However, after MPT migration, it will be shortened to 164, since `validatorRewardScalar` will be no longer included in the calldata. 

This was what I missed at #125, so I fixed the function to do separate checks with `isKromaMPT` boolean.