### PR TITLE
feat: delete all temporarily stored state changes for MPT migration

### DIFF
--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -210,6 +210,7 @@ func DeleteAllStateChanges(db ethdb.KeyValueStore) error {
 	batch := db.NewBatch()
 	deleteFunc := func(prefix []byte) error {
 		it := db.NewIterator(prefix, nil)
+		defer it.Release()
 		for it.Next() {
 			err := batch.Delete(it.Key())
 			if err != nil {

--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -205,3 +205,30 @@ func DeleteStateChanges(db ethdb.KeyValueStore, blockNumber uint64) error {
 	}
 	return batch.Write()
 }
+
+func DeleteAllStateChanges(db ethdb.KeyValueStore) error {
+	batch := db.NewBatch()
+	deleteFunc := func(prefix []byte) error {
+		it := db.NewIterator(prefix, nil)
+		for it.Next() {
+			err := batch.Delete(it.Key())
+			if err != nil {
+				return err
+			}
+		}
+		if it.Error() != nil {
+			return it.Error()
+		}
+		return nil
+	}
+	if err := deleteFunc(destructChangesPrefix); err != nil {
+		return err
+	}
+	if err := deleteFunc(accountChangesPrefix); err != nil {
+		return err
+	}
+	if err := deleteFunc(storageChangesPrefix); err != nil {
+		return err
+	}
+	return batch.Write()
+}


### PR DESCRIPTION
After the migration process is complete, delete any remaining temporary state changes data that might not have been removed.