### PR TITLE
fix(migration): skip the case of node deletion at hash collision check

### DIFF
--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -282,6 +282,9 @@ func (m *StateMigrator) commit(mpt *trie.StateTrie, parentHash common.Hash) (com
 
 	// NOTE(pangssu): It is possible that the keccak256 and poseidon hashes collide, and data loss can occur.
 	for path, mptNode := range set.Nodes {
+		if mptNode.IsDeleted() {
+			continue
+		}
 		data, _ := m.db.Get(mptNode.Hash.Bytes())
 		if len(data) == 0 {
 			continue


### PR DESCRIPTION
This adds a bypass for hash collision check if `mptNode` is an empty hash. `mptNode` can be empty when it is deleted, and this can lead to an unexpected behavior if the value exists when we check the db with empty hash.
