### PR TITLE
fix: remove the functionality for deleting all state changes

### DIFF
--- a/core/kroma_migration.go
+++ b/core/kroma_migration.go
@@ -205,31 +205,3 @@ func DeleteStateChanges(db ethdb.KeyValueStore, blockNumber uint64) error {
 	}
 	return batch.Write()
 }
-
-func DeleteAllStateChanges(db ethdb.KeyValueStore) error {
-	batch := db.NewBatch()
-	deleteFunc := func(prefix []byte) error {
-		it := db.NewIterator(prefix, nil)
-		defer it.Release()
-		for it.Next() {
-			err := batch.Delete(it.Key())
-			if err != nil {
-				return err
-			}
-		}
-		if it.Error() != nil {
-			return it.Error()
-		}
-		return nil
-	}
-	if err := deleteFunc(destructChangesPrefix); err != nil {
-		return err
-	}
-	if err := deleteFunc(accountChangesPrefix); err != nil {
-		return err
-	}
-	if err := deleteFunc(storageChangesPrefix); err != nil {
-		return err
-	}
-	return batch.Write()
-}

--- a/migration/migrator.go
+++ b/migration/migrator.go
@@ -324,15 +324,6 @@ func (m *StateMigrator) FinalizeTransition(transitionBlock types.Block) {
 	// Switch trie backend to MPT
 	cfg.Zktrie = false
 	m.backend.BlockChain().TrieDB().SetBackend(false)
-
-	// Delete all state changes.
-	go func() {
-		if err := core.DeleteAllStateChanges(m.db); err != nil {
-			log.Warn("Failed to delete all state changes for MPT migration", "err", err)
-		} else {
-			log.Info("All state changes have been deleted for MPT migration")
-		}
-	}()
 }
 
 func (m *StateMigrator) waitForMigrationReady(target *types.Header) {


### PR DESCRIPTION
# Description

Due to an issue where deleting state change also deletes trie nodes, the functionality for deleting state change data has been removed.

To explain in more detail, there is a process that deletes all keys starting with the prefix `aC-`, which is used to record account changes. However, when converting the hash of a trie node to a string, some hashes happened to start with `aC-`. Deleting these keys caused a "missing trie node" error. To prevent this issue, the code for deleting state changes has been removed.

Related: #138 
