### PR TITLE
fix: fix for unmarshal issues caused by WithdrawalsHash

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -293,7 +293,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType:
+	case DynamicFeeTxType, AccessListTxType, BlobTxType, SetCodeTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -428,7 +428,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType:
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType:
 		rlp.Encode(w, data)
 	case DepositTxType:
 		if r.DepositReceiptVersion != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1439,7 +1439,7 @@ func RPCMarshalBlock(ctx context.Context, block *types.Block, inclTx bool, fullT
 		uncleHashes[i] = uncle.Hash()
 	}
 	fields["uncles"] = uncleHashes
-	if block.Header().WithdrawalsHash != nil {
+	if block.Withdrawals() != nil {
 		fields["withdrawals"] = block.Withdrawals()
 	}
 	return fields, nil


### PR DESCRIPTION
# Description

WithdrawalsHash may not be nil even if block.Withdrawals is actually empty. 

This is defined by a special hash named EmptyWithdrawalsHash.

Note that checking for `block.Header().WithdrawalsHash != nil `does not guarantee that withdrawals exist in the block.
